### PR TITLE
docs: fix reload spelling in troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can customize the color coding of the Work Item Age, both the number of days
 ### 3. Extension Does Not Load
 - Ensure the extension is **enabled** in `edge://extensions/`.
 - Check the console (`F12` → Console) for errors.
-- If running manually, re-load the unpacked extension.
+- If running manually, reload the unpacked extension.
 
 ## Contribution
 


### PR DESCRIPTION
## Summary
- replace `re-load` with `reload` in README troubleshooting steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f87757a083318de285da82ad1934