### PR TITLE
feat: show done badge for resolved cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The **ServiceNow Visual Task Board Enhancer - Work Item Age** is a Microsoft Edg
   - **30–90 days**: Strong orange (`#e67e22`)
   - **90+ days**: Red (`#d9534f`)
 - Ensures contrast for readability.
+- Displays "Done" with a green badge if the card's **State** is *Resolved*, or contains *Closed* or *Canceled*.
 - Runs efficiently, avoiding duplicate processing of the same cards.
 
 ## Requirements

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.6",
+  "version": "0.7",
   "description": "Displays work item age on ServiceNow Visual Task Board cards based upon the Actual Start Date.",
   "permissions": [
     "storage"


### PR DESCRIPTION
## Summary
- show green "Done" badge when card state is Resolved, Closed, or Canceled
- add state lookup with `findState`
- bump extension version to 0.7 and document behavior

## Testing
- `node --check content.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899537dca9c833193642c313861452b