### PR TITLE
feat: allow board-specific age band colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The **ServiceNow Visual Task Board Enhancer - Work Item Age** is a Microsoft Edg
 - Ensures contrast for readability.
 - Displays "Done" with a green badge if the card's **State** is *Resolved*, or contains *Closed* or *Canceled*.
 - Runs efficiently, avoiding duplicate processing of the same cards.
+- Supports board-specific color bands while providing a global default configuration.
 
 ## Requirements
 
@@ -54,11 +55,12 @@ For this extension to function correctly, your ServiceNow instance must meet the
 
 ## Customization
 
-You can customize the color coding of the Work Item Age, both the number of days and the color, by using the Extension Options:
+You can customize the color coding of the Work Item Age, both the number of days and the color, by using the Extension Options. A default set applies to all boards, and any board you visit will appear in the options so you can tailor its colors independently:
 
 1. Click the extension icon in the Edge toolbar and select **Extension Options**.
-2. Adjust the age bands and colors as desired.
-3. Save your changes.
+2. Choose a board or select **Default (All Boards)** from the dropdown.
+3. Adjust the age bands and colors as desired.
+4. Save your changes.
 
 ## Troubleshooting
 

--- a/content.js
+++ b/content.js
@@ -19,7 +19,11 @@
     ],
   };
 
-  // Retrieve the configuration from chrome.storage.sync.
+  const defaultStorage = { defaultConfig: defaultConfig, boards: {} };
+
+  const boardIdMatch = window.location.href.match(/sysparm_board=([^&]+)/);
+  const boardId = boardIdMatch ? boardIdMatch[1] : null;
+
   function getConfig(callback) {
     if (
       typeof chrome !== 'undefined' &&
@@ -27,18 +31,55 @@
       chrome.storage.sync
     ) {
       chrome.storage.sync.get(
-        { vtbEnhancerConfig: defaultConfig },
+        { vtbEnhancerConfig: defaultStorage },
         function (data) {
-          callback(data.vtbEnhancerConfig);
+          let cfg = data.vtbEnhancerConfig;
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(cfg);
         }
       );
     } else {
-      callback(defaultConfig);
+      callback(defaultStorage);
+    }
+  }
+
+  function saveConfig(cfg, callback) {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
+    ) {
+      chrome.storage.sync.set({ vtbEnhancerConfig: cfg }, () => {
+        if (callback) callback();
+      });
+    } else {
+      localStorage.setItem('vtbEnhancerConfig', JSON.stringify(cfg));
+      if (callback) callback();
+    }
+  }
+
+  function updateBoardInfo(cfg) {
+    if (!boardId) return;
+    const label = document.querySelector('label.sn-navhub-title');
+    if (!label) return;
+    const name = label.textContent.trim();
+    if (!cfg.boards[boardId]) {
+      cfg.boards[boardId] = { name: name };
+      saveConfig(cfg);
+    } else if (cfg.boards[boardId].name !== name) {
+      cfg.boards[boardId].name = name;
+      saveConfig(cfg);
     }
   }
 
   // Load config then run the main logic.
-  getConfig(function (config) {
+  getConfig(function (fullConfig) {
+    const config =
+      boardId && fullConfig.boards[boardId] && fullConfig.boards[boardId].ageBands
+        ? fullConfig.boards[boardId]
+        : fullConfig.defaultConfig;
     // --- Utility Functions ---
     function showDebugMessage(msg) {
       const div = document.createElement('div');
@@ -228,6 +269,7 @@
 
     function init() {
       waitForBoardLoad(() => {
+        updateBoardInfo(fullConfig);
         processExistingCards();
         showDebugMessage(`Updated ${updatedCount} cards with Work Item Age`);
         observeCards();

--- a/content.js
+++ b/content.js
@@ -62,6 +62,8 @@
 
   function updateBoardInfo(cfg) {
     if (!boardId) return;
+    // Prevent prototype pollution
+    if (boardId === '__proto__' || boardId === 'constructor' || boardId === 'prototype') return;
     const label = document.querySelector('label.sn-navhub-title');
     if (!label) return;
     const name = label.textContent.trim();

--- a/options.html
+++ b/options.html
@@ -88,6 +88,10 @@
     <h1>ServiceNow Visual Task Board Enhancer</h1>
     <h1>Work Item Age Options</h1>
     <p>Configure the Work Item Age bands below. For each row, enter the maximum number of days and select the badge color. This will be the Work Item Age badge color for items less than this number of days. The last band (∞) represents no limit and only the color can be edited.</p>
+    <div style="margin-bottom:20px;">
+      <label for="boardSelect">Board:</label>
+      <select id="boardSelect"></select>
+    </div>
     <table id="ageBandsTable">
       <thead>
         <tr>

--- a/options.js
+++ b/options.js
@@ -1,188 +1,223 @@
-document.addEventListener('DOMContentLoaded', function() {
-    const defaultConfig = {
-      ageBands: [
-        { maxDays: 7, color: '#f9e79f' },
-        { maxDays: 30, color: '#f0ad4e' },
-        { maxDays: 90, color: '#e67e22' },
-        { maxDays: 9999, color: '#d9534f' }
-      ]
-    };
-  
-    const statusDiv = document.getElementById('status');
-    const tableBody = document.querySelector('#ageBandsTable tbody');
-  
-    // Load config from chrome.storage.sync or fallback to defaults.
-    function loadConfig(callback) {
-      if (
-        typeof chrome !== 'undefined' &&
-        chrome.storage &&
-        chrome.storage.sync
-      ) {
-        chrome.storage.sync.get(
-          { vtbEnhancerConfig: defaultConfig },
-          function (data) {
-            callback(data.vtbEnhancerConfig);
+document.addEventListener('DOMContentLoaded', function () {
+  const defaultConfig = {
+    ageBands: [
+      { maxDays: 7, color: '#f9e79f' },
+      { maxDays: 30, color: '#f0ad4e' },
+      { maxDays: 90, color: '#e67e22' },
+      { maxDays: 9999, color: '#d9534f' },
+    ],
+  };
+
+  const defaultStorage = { defaultConfig: defaultConfig, boards: {} };
+
+  const statusDiv = document.getElementById('status');
+  const tableBody = document.querySelector('#ageBandsTable tbody');
+  const boardSelect = document.getElementById('boardSelect');
+
+  let fullConfig = null;
+  let currentBoardId = null; // null means default config
+
+  // Load config from chrome.storage.sync or fallback to defaults.
+  function loadConfig(callback) {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
+    ) {
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
           }
-        );
-      } else {
-        callback(defaultConfig);
-      }
+          callback(cfg);
+        }
+      );
+    } else {
+      callback(defaultStorage);
     }
-  
-    // Save configuration using chrome.storage.sync.
-    function saveConfig(config, callback) {
-      if (
-        typeof chrome !== 'undefined' &&
-        chrome.storage &&
-        chrome.storage.sync
-      ) {
-        chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
-          if (callback) callback();
-        });
-      } else {
-        localStorage.setItem('vtbEnhancerConfig', JSON.stringify(config));
+  }
+
+  // Save configuration using chrome.storage.sync.
+  function saveConfig(config, callback) {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
+    ) {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
-      }
-    }
-  
-    // Render the table based directly on a provided configuration object.
-    function renderTableFromConfig(config) {
-      tableBody.innerHTML = '';
-      config.ageBands.forEach(band => {
-        const row = createRow(band);
-        tableBody.appendChild(row);
       });
+    } else {
+      localStorage.setItem('vtbEnhancerConfig', JSON.stringify(config));
+      if (callback) callback();
     }
+  }
   
-    // Create a table row for an age band.
-    function createRow(band) {
-      const tr = document.createElement('tr');
-  
-      // Max Days cell
-      const tdDays = document.createElement('td');
-      if (band.maxDays === 9999) {
-        const span = document.createElement('span');
-        span.textContent = '∞';
-        tdDays.appendChild(span);
+  // Render the table based directly on a provided configuration object.
+  function renderTableFromConfig(config) {
+    tableBody.innerHTML = '';
+    config.ageBands.forEach((band) => {
+      const row = createRow(band);
+      tableBody.appendChild(row);
+    });
+  }
+
+  function refreshTable() {
+    let bands = getBandsFromTable();
+    bands.sort((a, b) => a.maxDays - b.maxDays);
+    if (bands.length === 0 || bands[bands.length - 1].maxDays !== 9999) {
+      bands.push({ maxDays: 9999, color: '#d9534f' });
+    }
+    tableBody.innerHTML = '';
+    bands.forEach((band) => {
+      const row = createRow(band);
+      tableBody.appendChild(row);
+    });
+  }
+
+  function createRow(band) {
+    const tr = document.createElement('tr');
+
+    const tdDays = document.createElement('td');
+    if (band.maxDays === 9999) {
+      const span = document.createElement('span');
+      span.textContent = '∞';
+      tdDays.appendChild(span);
+    } else {
+      const inputDays = document.createElement('input');
+      inputDays.type = 'number';
+      inputDays.min = '0';
+      inputDays.value = band.maxDays;
+      tdDays.appendChild(inputDays);
+    }
+    tr.appendChild(tdDays);
+
+    const tdColor = document.createElement('td');
+    const inputColor = document.createElement('input');
+    inputColor.type = 'color';
+    inputColor.value = band.color;
+    tdColor.appendChild(inputColor);
+    tr.appendChild(tdColor);
+
+    const tdAction = document.createElement('td');
+    if (band.maxDays !== 9999) {
+      const deleteBtn = document.createElement('button');
+      deleteBtn.className = 'action-btn';
+      deleteBtn.textContent = '✕';
+      deleteBtn.title = 'Delete this age band';
+      deleteBtn.addEventListener('click', () => {
+        tr.remove();
+        refreshTable();
+      });
+      tdAction.appendChild(deleteBtn);
+    }
+    tr.appendChild(tdAction);
+
+    return tr;
+  }
+
+  function getBandsFromTable() {
+    const newBands = [];
+    const rows = tableBody.querySelectorAll('tr');
+    rows.forEach((row) => {
+      const daysInput = row.querySelector('td:nth-child(1) input');
+      let maxDays;
+      if (daysInput) {
+        maxDays = parseInt(daysInput.value, 10);
+        if (isNaN(maxDays) || maxDays < 0 || maxDays === 0) return;
       } else {
-        const inputDays = document.createElement('input');
-        inputDays.type = 'number';
-        inputDays.min = '0';
-        inputDays.value = band.maxDays;
-        tdDays.appendChild(inputDays);
+        maxDays = 9999;
       }
-      tr.appendChild(tdDays);
-  
-      // Color cell
-      const tdColor = document.createElement('td');
-      const inputColor = document.createElement('input');
-      inputColor.type = 'color';
-      inputColor.value = band.color;
-      tdColor.appendChild(inputColor);
-      tr.appendChild(tdColor);
-  
-      // Action cell
-      const tdAction = document.createElement('td');
-      if (band.maxDays !== 9999) {
-        const deleteBtn = document.createElement('button');
-        deleteBtn.className = 'action-btn';
-        deleteBtn.textContent = '✕';
-        deleteBtn.title = 'Delete this age band';
-        deleteBtn.addEventListener('click', () => {
-          tr.remove();
-          renderTable();
-        });
-        tdAction.appendChild(deleteBtn);
+      const colorInput = row.querySelector('td:nth-child(2) input');
+      newBands.push({ maxDays: maxDays, color: colorInput.value });
+    });
+    return newBands;
+  }
+
+  function populateBoardSelect() {
+    boardSelect.innerHTML = '';
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = 'Default (All Boards)';
+    boardSelect.appendChild(defaultOption);
+    Object.keys(fullConfig.boards).forEach((id) => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = fullConfig.boards[id].name || id;
+      boardSelect.appendChild(opt);
+    });
+    boardSelect.value = currentBoardId || '';
+  }
+
+  function getCurrentConfig() {
+    if (!currentBoardId) return fullConfig.defaultConfig;
+    const board = fullConfig.boards[currentBoardId];
+    if (board && board.ageBands) return board;
+    // return copy of default bands
+    return { ageBands: fullConfig.defaultConfig.ageBands.map((b) => ({ ...b })) };
+  }
+
+  boardSelect.addEventListener('change', () => {
+    currentBoardId = boardSelect.value || null;
+    renderTableFromConfig(getCurrentConfig());
+  });
+
+  document.getElementById('addRowBtn').addEventListener('click', () => {
+    let bands = getBandsFromTable();
+    const infinityBand =
+      bands.find((b) => b.maxDays === 9999) || { maxDays: 9999, color: '#d9534f' };
+    bands.push({ maxDays: 1, color: '#ffffff' });
+    bands = bands.filter((b) => b.maxDays !== 9999);
+    bands.sort((a, b) => a.maxDays - b.maxDays);
+    bands.push(infinityBand);
+    tableBody.innerHTML = '';
+    bands.forEach((band) => tableBody.appendChild(createRow(band)));
+  });
+
+  document.getElementById('saveBtn').addEventListener('click', () => {
+    const newBands = getBandsFromTable();
+    if (currentBoardId) {
+      if (!fullConfig.boards[currentBoardId]) {
+        fullConfig.boards[currentBoardId] = {
+          name: boardSelect.options[boardSelect.selectedIndex].text,
+        };
       }
-      tr.appendChild(tdAction);
-  
-      return tr;
+      fullConfig.boards[currentBoardId].ageBands = newBands;
+    } else {
+      fullConfig.defaultConfig.ageBands = newBands;
     }
-  
-    // Gather age bands from the current table; discard rows with 0 as maxDays.
-    function getBandsFromTable() {
-      const newBands = [];
-      const rows = tableBody.querySelectorAll('tr');
-      rows.forEach(row => {
-        const daysInput = row.querySelector('td:nth-child(1) input');
-        let maxDays;
-        if (daysInput) {
-          maxDays = parseInt(daysInput.value, 10);
-          if (isNaN(maxDays) || maxDays < 0 || maxDays === 0) return;
-        } else {
-          maxDays = 9999;
-        }
-        const colorInput = row.querySelector('td:nth-child(2) input');
-        newBands.push({ maxDays: maxDays, color: colorInput.value });
-      });
-      newBands.sort((a, b) => a.maxDays - b.maxDays);
-      if (newBands.length === 0 || newBands[newBands.length - 1].maxDays !== 9999) {
-        newBands.push({ maxDays: 9999, color: '#d9534f' });
-      }
-      return newBands;
-    }
-  
-    // Re-render the table using unsaved changes if available; otherwise, load from storage.
-    function renderTable() {
-      loadConfig(function(config) {
-        let bands = getBandsFromTable();
-        if (bands.length === 0) {
-          bands = config.ageBands;
-        }
-        bands.sort((a, b) => a.maxDays - b.maxDays);
-        if (bands.length === 0 || bands[bands.length - 1].maxDays !== 9999) {
-          bands.push({ maxDays: 9999, color: '#d9534f' });
-        }
-        tableBody.innerHTML = '';
-        bands.forEach(band => {
-          const row = createRow(band);
-          tableBody.appendChild(row);
-        });
-      });
-    }
-  
-    document.getElementById('addRowBtn').addEventListener('click', () => {
-      loadConfig(function (config) {
-        let bands = getBandsFromTable();
-        const infinityBand =
-          bands.find((b) => b.maxDays === 9999) || {
-            maxDays: 9999,
-            color: '#d9534f',
-          };
-        bands.push({ maxDays: 1, color: '#ffffff' });
-        // Remove any existing 9999 band, then re-add it at the end using its previous color.
-        bands = bands.filter((b) => b.maxDays !== 9999);
-        bands.sort((a, b) => a.maxDays - b.maxDays);
-        bands.push(infinityBand);
-        tableBody.innerHTML = '';
-        bands.forEach((band) => {
-          const row = createRow(band);
-          tableBody.appendChild(row);
-        });
-      });
-    });
-  
-    document.getElementById('saveBtn').addEventListener('click', () => {
-      const newBands = getBandsFromTable();
-      const config = { ageBands: newBands };
-      saveConfig(config, function() {
-        statusDiv.textContent = 'Configuration saved.';
-        setTimeout(() => { statusDiv.textContent = ''; }, 2000);
-      });
-    });
-  
-    // When "Reset to Default" is clicked, save the default config and re-render immediately.
-    document.getElementById('resetBtn').addEventListener('click', () => {
-      saveConfig(defaultConfig, function() {
-        renderTableFromConfig(defaultConfig);
-        statusDiv.textContent = 'Configuration reset to default.';
-        setTimeout(() => { statusDiv.textContent = ''; }, 2000);
-      });
-    });
-  
-    // On initial page load, pull configuration from chrome.storage.sync and render the table.
-    loadConfig(function(config) {
-      renderTableFromConfig(config);
+    saveConfig(fullConfig, function () {
+      statusDiv.textContent = 'Configuration saved.';
+      setTimeout(() => {
+        statusDiv.textContent = '';
+      }, 2000);
     });
   });
+
+  document.getElementById('resetBtn').addEventListener('click', () => {
+    if (currentBoardId) {
+      if (fullConfig.boards[currentBoardId]) {
+        delete fullConfig.boards[currentBoardId].ageBands;
+      }
+    } else {
+      fullConfig.defaultConfig.ageBands = defaultConfig.ageBands.map((b) => ({ ...b }));
+    }
+    renderTableFromConfig(getCurrentConfig());
+    saveConfig(fullConfig, function () {
+      statusDiv.textContent = 'Configuration reset to default.';
+      setTimeout(() => {
+        statusDiv.textContent = '';
+      }, 2000);
+    });
+  });
+
+  loadConfig(function (config) {
+    fullConfig = config;
+    populateBoardSelect();
+    renderTableFromConfig(getCurrentConfig());
+  });
+});
   


### PR DESCRIPTION
## Summary
- support storing age-band settings per board with global fallback
- add board selector to options page to customize individual boards
- track board name changes and apply board-specific colors on boards

## Testing
- `node --check options.js`
- `node --check content.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1355a7f388331a99077d1ec5bd59d