### PR TITLE
Fallback to Opened date when Actual Start Date missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-The **ServiceNow Visual Task Board Enhancer - Work Item Age** is a Microsoft Edge Extension designed to enhance Visual Task Boards (VTBs) in ServiceNow by displaying the Work Item Age in days. The Work Item Age is calculated as the difference between the **Actual Start Date** and the current date. This extension visually highlights task age with color-coded badges to improve task tracking and prioritization.
+The **ServiceNow Visual Task Board Enhancer - Work Item Age** is a Microsoft Edge Extension designed to enhance Visual Task Boards (VTBs) in ServiceNow by displaying the Work Item Age in days. The age is derived from the card's **Actual Start Date** whenever available. That field is preferred because teams can manage it independently of when the record was created. If no Actual Start Date is present, the extension falls back to the **Opened** date so cards still show an age. This extension visually highlights task age with color-coded badges to improve task tracking and prioritization.
 
 ![What the badges look like in a ServiceNow Visual Task Board](images/screenshot1.png)
 
 ## Features
 
 - Automatically identifies task cards on ServiceNow Visual Task Boards.
-- Extracts the **Actual Start Date** field from each card.
+- Prefers the **Actual Start Date** field, which teams can manage independently of the **Opened** date, and uses **Opened** only as a backup when no Actual Start Date is maintained.
 - Calculates and displays the Work Item Age in a badge at the bottom of each card.
 - Uses customizable color-coding to indicate urgency. Here are the defaults:
   - **< 7 days**: Light yellow (`#f9e79f`)
@@ -25,10 +25,10 @@ The **ServiceNow Visual Task Board Enhancer - Work Item Age** is a Microsoft Edg
 
 For this extension to function correctly, your ServiceNow instance must meet the following conditions:
 
-1. **The "Actual Start Date" field must be included in the VTB form view** for the task types you wish to track.
-   - This requires configuring the form layout to include the **Actual Start Date** field in the "VTB" view (this view may need to be created if it does not already exist). The field does not need to be visible on the card by default; however, it must be part of the form view to ensure the data is available to the extension. 
+1. **Include the "Actual Start Date" field in the VTB form view** for the task types you wish to track. This field is preferred because it can be set independently of when the record was opened. If it isn't available, ensure the **Opened** field is present so the extension can use it as a backup.
+   - This requires configuring the form layout to include the relevant field in the "VTB" view (this view may need to be created if it does not already exist). The field does not need to be visible on the card by default; however, it must be part of the form view to ensure the data is available to the extension.
 
-2. **The "Actual Start Date" must be populated** by an external process.
+2. **Populate the "Actual Start Date"** through state changes, workflows, or other automation. When this field isn't managed, the extension falls back to the **Opened** date, which may not reflect when work actually began.
    - There are some out of the box processes in ServiceNow that automatically set **Actual Start Date**. One example is when a task (enhancement, story, etc.) moves into a Work in Progress state. You must ensure that this field is populated through state changes, workflows, business rules, automation scripts (like with Flow Designer), or manual entry.
 
 ![Highlighting the requirements of having Actual start date on the VTB view of the task.](images/screenshot2.png)
@@ -49,7 +49,7 @@ For this extension to function correctly, your ServiceNow instance must meet the
 ## Usage
 
 1. Navigate to your **ServiceNow Visual Task Board** (it must have `vtb.do` somewhere in the URL to run).
-2. Open any board where task cards include the **Actual Start Date** in their VTB form view. This can be shown by turning on Show Card Info on the Visual Task Board settings (shown in the image above).
+2. Open any board where task cards include the **Actual Start Date** (preferred) or at least the **Opened** date for fallback in their VTB form view. This can be shown by turning on Show Card Info on the Visual Task Board settings (shown in the image above).
 3. If the extension is working, each card will display an "Age" badge at the bottom.
 4. The badge will be color-coded based on task age.
 
@@ -65,13 +65,13 @@ You can customize the color coding of the Work Item Age, both the number of days
 ## Troubleshooting
 
 ### 1. No Work Item Age is Displayed
-- Ensure that the **Actual Start Date** field is included in the VTB form view for the relevant task types.
-- Confirm that the **Actual Start Date** is populated.
+- Ensure that the **Actual Start Date** field is included in the VTB form view for the relevant task types. If it's not being used, the **Opened** field must be available as a backup.
+- Confirm that the **Actual Start Date** is populated. If it's not managed, verify that the **Opened** date exists so the extension can fall back to it.
 - Turn on Show Card Info on the Visual Task Board settings to force ServiceNow to send this field to the browser.
 - Refresh the page or reload the extension.
 
 ### 2. Incorrect or Unexpected Values
-- Verify that the **Actual Start Date** is correctly formatted and valid.
+- Verify that the **Actual Start Date** or **Opened** date is correctly formatted and valid.
 - Check if any ServiceNow customizations or security restrictions are preventing access to card data.
 
 ### 3. Extension Does Not Load

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
   "version": "0.8.1",
-  "description": "Displays work item age on ServiceNow Visual Task Board cards based upon the Actual Start Date.",
+  "description": "Displays work item age on ServiceNow Visual Task Board cards, preferring Actual Start Date and falling back to the Opened date when no start date is managed.",
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
## Summary
- Highlight that Actual Start Date is the preferred source for calculating card age because it can be managed separately from record creation
- Document and comment that Opened date is only used as a backup when Actual Start Date is absent

## Testing
- `node --check content.js`
- `node -p "require('./manifest.json')"`
- `node --check options.js`


------
https://chatgpt.com/codex/tasks/task_e_68a479076d008331898a8fcf73d115c6