### PR TITLE
chore: update artifact action to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         run: zip -r edge-extension.zip . -x ".*" "*.zip" "LICENSE" "README.md" "bump-version.js" "*screenshot*" "package.json"
 
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: edge-extension
           path: edge-extension.zip


### PR DESCRIPTION
## Summary
- use newer `actions/upload-artifact@v4` in release workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a643b58fb8833183396df64679ddb6