### PR TITLE
Adjust release artifact to avoid double zipping

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,11 +28,20 @@ jobs:
           git commit -m "Bump version" || echo "No changes"
           git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
 
-      - name: Package extension
-        run: zip -r edge-extension.zip . -x ".*" "*.zip" "LICENSE" "README.md" "bump-version.js" "*screenshot*" "package.json"
-
       - name: Upload package
         uses: actions/upload-artifact@v4
         with:
           name: edge-extension
-          path: edge-extension.zip
+          path: |
+            ./**
+            !./**/.*
+            !./.git/**
+            !./.github/**
+            !./.gitignore
+            !./LICENSE
+            !./README.md
+            !./bump-version.js
+            !./package.json
+            !./package-lock.json
+            !./**/*screenshot*
+            !./**/*.zip


### PR DESCRIPTION
## Summary
- remove the manual zip packaging step from the release workflow so the published artifact is no longer double compressed
- upload only the extension files through the artifact step while excluding repository metadata and screenshots

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cca83b3f0c83319026dbee5455f6a0