### PR TITLE
Improve freshness indicator timestamp parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The **ServiceNow Visual Task Board Enhancer - Work Item Age** is a Microsoft Edg
 - Displays "Done" with a green badge whenever the card's **State** reads as a completion status (for example *Resolved*, *Closed*, *Canceled/Cancelled*, *Complete*, *Completed*, *Discarded*, *Done*, *Fulfilled*, *Finished*, *Finalized*, or *Accomplished*).
 - Runs efficiently, avoiding duplicate processing of the same cards.
 - Supports board-specific color bands while providing a global default configuration.
+- Highlights card freshness with a green checkmark or red X based on whether the last update happened within a configurable, per-board threshold (6 days by default).
+- Lets each board pick the exact emoji shown for fresh and stale updates while falling back to the default ✅ / ❌ pair.
 
 ## How Work Item Age is Determined
 
@@ -66,11 +68,11 @@ For this extension to function correctly, your ServiceNow instance must meet the
 
 ## Customization
 
-You can customize the color coding of the Work Item Age, both the number of days and the color, by using the Extension Options. A default set applies to all boards, and any board you visit will appear in the options so you can tailor its colors independently:
+You can customize the color coding of the Work Item Age—both the number of days and the color—and tune the update freshness threshold by using the Extension Options. A default set applies to all boards, and any board you visit will appear in the options so you can tailor its colors and freshness window independently:
 
 1. Click the extension icon in the Edge toolbar and select **Extension Options**.
 2. Choose a board or select **Default (All Boards)** from the dropdown.
-3. Adjust the age bands and colors as desired.
+3. Adjust the age bands, colors, update threshold, and freshness emoji as desired.
 4. Save your changes.
 
 ## Troubleshooting

--- a/options.html
+++ b/options.html
@@ -46,6 +46,13 @@
       border: 1px solid #ccc;
       border-radius: 4px;
     }
+    input[type="text"] {
+      width: 100%;
+      padding: 8px;
+      box-sizing: border-box;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
     /* Style the color picker so the chosen color is clearly visible */
     input[type="color"] {
       width: 50px;
@@ -81,6 +88,19 @@
       cursor: pointer;
       font-size: 16px;
     }
+    .field-group {
+      margin-bottom: 20px;
+    }
+    .field-group label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 500;
+    }
+    .field-help {
+      font-size: 12px;
+      color: #666;
+      margin-top: 4px;
+    }
   </style>
 </head>
 <body>
@@ -88,9 +108,28 @@
     <h1>ServiceNow Visual Task Board Enhancer</h1>
     <h1>Work Item Age Options</h1>
     <p>Configure the Work Item Age bands below. For each row, enter the maximum number of days and select the badge color. This will be the Work Item Age badge color for items less than this number of days. The last band (∞) represents no limit and only the color can be edited.</p>
-    <div style="margin-bottom:20px;">
+    <div class="field-group">
       <label for="boardSelect">Board:</label>
       <select id="boardSelect"></select>
+    </div>
+    <div class="field-group">
+      <label for="thresholdInput">Update threshold (days):</label>
+      <input type="number" id="thresholdInput" min="0" step="0.1">
+      <p class="field-help">Cards updated within this many days display the "fresh" emoji. Older cards show the "stale" emoji.</p>
+    </div>
+    <div class="field-group">
+      <label>Update status emoji:</label>
+      <div style="display:flex; gap:12px; flex-wrap:wrap; align-items:flex-start;">
+        <div style="flex:1; min-width:120px;">
+          <label for="freshEmojiInput" style="font-weight:400;">Fresh (within threshold)</label>
+          <input type="text" id="freshEmojiInput" maxlength="8">
+        </div>
+        <div style="flex:1; min-width:120px;">
+          <label for="staleEmojiInput" style="font-weight:400;">Stale (over threshold)</label>
+          <input type="text" id="staleEmojiInput" maxlength="8">
+        </div>
+      </div>
+      <p class="field-help">Choose the emoji shown after the “time ago” text. Leave blank to fall back to the default ✅ / ❌ icons.</p>
     </div>
     <table id="ageBandsTable">
       <thead>


### PR DESCRIPTION
## Summary
- expand timestamp parsing with multiple fallbacks to handle varied ServiceNow date formats
- read update timestamps from time elements and ancestors using additional attributes to keep freshness indicators visible
- observe more attribute changes on time and container elements so indicators refresh after rerenders

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68ee96d1c64c8331a7a262d725298133)