### PR TITLE
Bump to v0.9.3; add .DS_Store to .gitignore; upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get version
         id: version

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
+.DS_Store
 .vscode/settings.json

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"


### PR DESCRIPTION
## Summary

- **Bump to v0.9.3** — correctly versions the bug fix from #21, which shipped under v0.9.2
- **Add `.DS_Store` to `.gitignore`** — prevents macOS metadata files from appearing as uncommitted changes
- **Upgrade `actions/checkout@v3` → `@v4`** — required before the GitHub Actions Node.js 20 deprecation deadline (June 2, 2026)

## Test plan

- [ ] CI produces a `v0.9.3` GitHub Release with both Edge and Safari zips on merge