### PR TITLE
Add Edge Add-ons store publish step to CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,3 +41,82 @@ jobs:
             --generate-notes \
             "snvtb-enhancer-edge-v${VERSION}.zip" \
             "snvtb-enhancer-safari-v${VERSION}.zip"
+
+      - name: Publish to Microsoft Edge Add-ons
+        env:
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_PRODUCT_ID: ${{ vars.EDGE_PRODUCT_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ZIP="snvtb-enhancer-edge-v${VERSION}.zip"
+          API="https://api.addons.microsoftedge.microsoft.com"
+
+          # Upload the package
+          echo "Uploading package to Edge Add-ons..."
+          UPLOAD_RESP=$(curl -si \
+            -H "Authorization: ApiKey ${EDGE_API_KEY}" \
+            -H "X-ClientID: ${EDGE_CLIENT_ID}" \
+            -H "Content-Type: application/zip" \
+            -X POST \
+            -T "${ZIP}" \
+            "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions/draft/package")
+
+          HTTP_CODE=$(echo "$UPLOAD_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
+          if [ "$HTTP_CODE" != "202" ]; then
+            echo "Upload failed (HTTP $HTTP_CODE):"
+            echo "$UPLOAD_RESP"
+            exit 1
+          fi
+
+          OPERATION_ID=$(echo "$UPLOAD_RESP" | grep -i "^location:" | awk '{print $2}' | tr -d '\r' | sed 's|.*/||')
+          echo "Upload accepted, operation: ${OPERATION_ID}"
+
+          # Poll until the package is validated
+          echo "Waiting for package validation..."
+          STATUS=""
+          for i in $(seq 1 24); do
+            sleep 10
+            STATUS_RESP=$(curl -s \
+              -H "Authorization: ApiKey ${EDGE_API_KEY}" \
+              -H "X-ClientID: ${EDGE_CLIENT_ID}" \
+              "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions/draft/package/operations/${OPERATION_ID}")
+            STATUS=$(echo "$STATUS_RESP" | jq -r '.status // empty')
+            echo "  Attempt ${i}/24: ${STATUS}"
+            [ "$STATUS" = "Succeeded" ] && break
+            if [ "$STATUS" = "Failed" ]; then
+              echo "Package validation failed:"
+              echo "$STATUS_RESP" | jq .
+              exit 1
+            fi
+          done
+
+          if [ "$STATUS" != "Succeeded" ]; then
+            echo "Timed out waiting for package validation after 4 minutes"
+            exit 1
+          fi
+
+          # Use GitHub Release notes as certification notes for Microsoft's review
+          NOTES=$(gh release view "v${VERSION}" --json body -q .body 2>/dev/null \
+            || echo "Version ${VERSION} — see https://github.com/mikesnowbie/SNVTBEnhancer/releases/tag/v${VERSION}")
+
+          # Submit the draft for review
+          echo "Submitting v${VERSION} for Microsoft review..."
+          PUBLISH_RESP=$(curl -si \
+            -H "Authorization: ApiKey ${EDGE_API_KEY}" \
+            -H "X-ClientID: ${EDGE_CLIENT_ID}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "{\"notes\": $(echo "$NOTES" | jq -Rs .)}" \
+            "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions")
+
+          HTTP_CODE=$(echo "$PUBLISH_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
+          if [ "$HTTP_CODE" != "202" ]; then
+            echo "Submission failed (HTTP $HTTP_CODE):"
+            echo "$PUBLISH_RESP"
+            exit 1
+          fi
+
+          echo "Successfully submitted v${VERSION} to Microsoft Edge Add-ons for review."
+          echo "Users will receive the update automatically after Microsoft completes their review."

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"


### PR DESCRIPTION
## Summary

Adds an automated publish step to the CI pipeline so that merging to \`main\` now fully delivers a new version to end users (pending Microsoft's review).

**What CI does on every merge to main:**
1. Builds Edge and Safari zips (unchanged)
2. Creates a versioned GitHub Release with both zips (unchanged)
3. **New:** Uploads the Edge zip to the Microsoft Edge Add-ons API (v1.1)
4. **New:** Polls until Microsoft validates the package
5. **New:** Submits the draft for Microsoft's review, using the auto-generated GitHub Release notes as the certification notes

**Secrets/config used:**
- \`EDGE_API_KEY\` — GitHub Secret
- \`EDGE_CLIENT_ID\` — GitHub Secret
- \`EDGE_PRODUCT_ID\` — GitHub Variable (non-sensitive)

**Also cleaned up:**
- Removed stale \`GIT_USER_EMAIL\`, \`GIT_USER_NAME\`, and \`EDGE_PRODUCT_ID\` secrets left over from the old CI workflow

**Limitation:** Store description and metadata updates still require Partner Center manually — the Microsoft Edge Add-ons API does not expose endpoints for metadata changes.

## Test plan

- [ ] Merge triggers CI; "Publish to Microsoft Edge Add-ons" step completes without error
- [ ] Submission appears in Partner Center as "In Review"
- [ ] Certification notes in Partner Center match the GitHub Release notes for this version