### PR TITLE
Fix Edge zip to exclude screenshots; bump to v0.9.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,15 +21,15 @@ jobs:
       - name: Build Edge extension zip
         run: |
           zip snvtb-enhancer-edge-v${{ steps.version.outputs.version }}.zip \
-            content.js options.html options.js manifest.json
-          zip -r snvtb-enhancer-edge-v${{ steps.version.outputs.version }}.zip images/
+            content.js options.html options.js manifest.json \
+            images/icon16.png images/icon48.png images/icon128.png
 
       - name: Build Safari extension zip
         run: |
           cd safari-extension
           zip ../snvtb-enhancer-safari-v${{ steps.version.outputs.version }}.zip \
-            content.js options.html options.js manifest.json
-          zip -r ../snvtb-enhancer-safari-v${{ steps.version.outputs.version }}.zip images/
+            content.js options.html options.js manifest.json \
+            images/icon16.png images/icon48.png images/icon128.png
 
       - name: Create GitHub Release
         env:

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"


### PR DESCRIPTION
## Summary

The v0.9.4 CI run successfully uploaded the package but Microsoft's validation rejected it. The zip included `images/screenshot1.png` and `images/screenshot2.png` which belong in the store listing, not inside the extension package.

Fix: explicitly list only the three icon files referenced in `manifest.json` (`icon16.png`, `icon48.png`, `icon128.png`) instead of zipping the entire `images/` directory. Same fix applied to the Safari zip.

## Test plan

- [ ] CI "Publish to Microsoft Edge Add-ons" step completes without error
- [ ] Submission appears in Partner Center as "In Review"