### PR TITLE
Force Node.js 24 for GitHub Actions; bump to v0.9.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"


### PR DESCRIPTION
Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the job level in `release.yaml`, resolving the deprecation warning that has appeared in every CI run since the Node.js 20 → 24 migration was announced. Actions will now run on Node.js 24 immediately rather than waiting for the June 2nd forced cutover.

## Test plan
- [ ] CI run completes with no Node.js deprecation warning