### PR TITLE
Add WIP-lane-aware freshness indicators

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.7
+  Version 0.10.0
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
   - Processes each card to calculate and display an "Age" badge. It prefers the card’s "Actual start date", which teams can manage independently of when the record was opened, and treats "Start date" as the same starting point before finally falling back to "Opened" when no start date exists.
@@ -117,6 +117,13 @@
                     : cfg.defaultConfig.updateIndicator.staleEmoji,
               };
             }
+
+            if (!Array.isArray(boardCfg.wipLanes)) {
+              boardCfg.wipLanes = [];
+            }
+            if (!Array.isArray(boardCfg.lanes)) {
+              boardCfg.lanes = [];
+            }
           });
           callback(cfg);
         }
@@ -148,12 +155,21 @@
     const label = document.querySelector('label.sn-navhub-title');
     if (!label) return;
     const name = label.textContent.trim();
+    const discoveredLanes = discoverLanes();
     if (!cfg.boards[boardId]) {
-      cfg.boards[boardId] = { name: name };
+      cfg.boards[boardId] = { name, lanes: discoveredLanes };
       saveConfig(cfg);
-    } else if (cfg.boards[boardId].name !== name) {
-      cfg.boards[boardId].name = name;
-      saveConfig(cfg);
+    } else {
+      let changed = false;
+      if (cfg.boards[boardId].name !== name) {
+        cfg.boards[boardId].name = name;
+        changed = true;
+      }
+      if (discoveredLanes.length > 0) {
+        cfg.boards[boardId].lanes = discoveredLanes;
+        changed = true;
+      }
+      if (changed) saveConfig(cfg);
     }
   }
 
@@ -198,6 +214,8 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      // wipLanes: empty array means show on all cards; non-empty restricts to named lanes only.
+      wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -323,6 +341,15 @@
     }
 
     function computeUpdateIndicatorState(timeElement) {
+      // When WIP lanes are configured, suppress the indicator on non-WIP cards.
+      if (config.wipLanes && config.wipLanes.length > 0) {
+        const card = timeElement.closest('.vtb-card-component-wrapper');
+        if (card) {
+          const laneName = findCardLane(card);
+          if (laneName !== null && !config.wipLanes.includes(laneName)) return null;
+        }
+      }
+
       const timestampString = getTimestampString(timeElement);
       const lastUpdated = parseServiceNowDateTime(timestampString);
       if (!lastUpdated) return null;
@@ -543,6 +570,55 @@
 
     function normalizeDateLabel(text) {
       return text.trim().replace(/\s*:\s*$/, '').toLocaleLowerCase();
+    }
+
+    // CSS selectors tried in order when searching for a lane/column title element.
+    // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+    const LANE_TITLE_SELECTORS = [
+      '.vtb-lane-header-title',
+      '.sn-board-header-title',
+      '.vtb-board-header-title',
+      '[class*="lane-header"] [class*="title"]',
+      '[class*="lane"] > [class*="header"] > [class*="title"]',
+    ];
+
+    // Returns the lane (column) name for a given card by walking up the DOM.
+    function findCardLane(card) {
+      let el = card.parentElement;
+      while (el && el !== document.body) {
+        for (const sel of LANE_TITLE_SELECTORS) {
+          try {
+            const found = el.querySelector(sel);
+            if (found) {
+              const text = found.textContent.trim();
+              if (text) return text;
+            }
+          } catch (_) {}
+        }
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    // Returns all unique lane names currently visible on the board.
+    function discoverLanes() {
+      const lanes = [];
+      for (const sel of LANE_TITLE_SELECTORS) {
+        try {
+          document.querySelectorAll(sel).forEach((el) => {
+            const text = el.textContent.trim();
+            if (text && !lanes.includes(text)) lanes.push(text);
+          });
+        } catch (_) {}
+      }
+      // Fallback: derive from cards if direct header query found nothing
+      if (lanes.length === 0) {
+        document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+          const lane = findCardLane(card);
+          if (lane && !lanes.includes(lane)) lanes.push(lane);
+        });
+      }
+      return lanes;
     }
 
     const DATE_LABELS = {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/options.html
+++ b/options.html
@@ -197,6 +197,23 @@
         color: #666;
         margin-top: 4px;
       }
+      .lane-checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 0;
+      }
+      .lane-checkbox-item input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .lane-checkbox-item label {
+        cursor: pointer;
+        font-weight: 400;
+        margin: 0;
+      }
     </style>
   </head>
   <body>
@@ -310,6 +327,16 @@
             Choose the emoji shown after the "time ago" text. Leave blank to
             fall back to the default icons.
           </p>
+        </div>
+        <div class="field-group" id="wipLanesSection" style="display:none;">
+          <label>WIP Lanes:</label>
+          <p class="field-help">
+            Check the lanes where the freshness indicator should appear. Leave
+            all unchecked to show on every card regardless of lane.
+          </p>
+          <div id="wipLanesList" style="margin-top: 8px;">
+            <!-- dynamically populated by options.js -->
+          </div>
         </div>
         <div class="preview-card" id="updatePreview">
           <div class="preview-text" style="width:100%;">

--- a/options.js
+++ b/options.js
@@ -43,6 +43,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const wipLanesSection = document.getElementById('wipLanesSection');
+  const wipLanesList = document.getElementById('wipLanesList');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
@@ -174,6 +176,50 @@ document.addEventListener('DOMContentLoaded', function () {
     return { freshEmoji: fresh, staleEmoji: stale };
   }
 
+  function renderWipLanes(boardId) {
+    if (!boardId) {
+      wipLanesSection.style.display = 'none';
+      return;
+    }
+    const boardCfg = fullConfig.boards[boardId];
+    const lanes = (boardCfg && Array.isArray(boardCfg.lanes)) ? boardCfg.lanes : [];
+    const wipLanes = (boardCfg && Array.isArray(boardCfg.wipLanes)) ? boardCfg.wipLanes : [];
+
+    wipLanesList.innerHTML = '';
+    if (lanes.length === 0) {
+      const hint = document.createElement('p');
+      hint.className = 'field-help';
+      hint.textContent = 'No lanes discovered yet. Visit this board in ServiceNow, then return here to configure WIP lanes.';
+      wipLanesList.appendChild(hint);
+    } else {
+      lanes.forEach((lane) => {
+        const item = document.createElement('div');
+        item.className = 'lane-checkbox-item';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        const safeId = 'lane-' + lane.replace(/[^a-z0-9]/gi, '-');
+        cb.id = safeId;
+        cb.value = lane;
+        cb.checked = wipLanes.includes(lane);
+        const lbl = document.createElement('label');
+        lbl.htmlFor = safeId;
+        lbl.textContent = lane;
+        item.appendChild(cb);
+        item.appendChild(lbl);
+        wipLanesList.appendChild(item);
+      });
+    }
+    wipLanesSection.style.display = '';
+  }
+
+  function getWipLanesFromUI() {
+    const checked = [];
+    wipLanesList.querySelectorAll('input[type="checkbox"]:checked').forEach((cb) => {
+      checked.push(cb.value);
+    });
+    return checked;
+  }
+
   function toggleSettingsVisibility() {
     const showAge = ageBadgeToggle.checked;
     const showUpdate = updateIndicatorToggle.checked;
@@ -249,6 +295,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    renderWipLanes(currentBoardId);
   }
 
   function refreshTable() {
@@ -432,6 +480,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].wipLanes = getWipLanesFromUI();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -455,6 +504,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].wipLanes;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.9.2 (Safari)
+  Version 0.10.0 (Safari)
   - Uses browser.* namespace (WebExtensions API) for Safari compatibility.
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
@@ -118,6 +118,13 @@
                   : cfg.defaultConfig.updateIndicator.staleEmoji,
             };
           }
+
+          if (!Array.isArray(boardCfg.wipLanes)) {
+            boardCfg.wipLanes = [];
+          }
+          if (!Array.isArray(boardCfg.lanes)) {
+            boardCfg.lanes = [];
+          }
         });
         callback(cfg);
       }).catch(function () {
@@ -152,12 +159,21 @@
     const label = document.querySelector('label.sn-navhub-title');
     if (!label) return;
     const name = label.textContent.trim();
+    const discoveredLanes = discoverLanes();
     if (!cfg.boards[boardId]) {
-      cfg.boards[boardId] = { name: name };
+      cfg.boards[boardId] = { name, lanes: discoveredLanes };
       saveConfig(cfg);
-    } else if (cfg.boards[boardId].name !== name) {
-      cfg.boards[boardId].name = name;
-      saveConfig(cfg);
+    } else {
+      let changed = false;
+      if (cfg.boards[boardId].name !== name) {
+        cfg.boards[boardId].name = name;
+        changed = true;
+      }
+      if (discoveredLanes.length > 0) {
+        cfg.boards[boardId].lanes = discoveredLanes;
+        changed = true;
+      }
+      if (changed) saveConfig(cfg);
     }
   }
 
@@ -202,6 +218,8 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      // wipLanes: empty array means show on all cards; non-empty restricts to named lanes only.
+      wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -327,6 +345,15 @@
     }
 
     function computeUpdateIndicatorState(timeElement) {
+      // When WIP lanes are configured, suppress the indicator on non-WIP cards.
+      if (config.wipLanes && config.wipLanes.length > 0) {
+        const card = timeElement.closest('.vtb-card-component-wrapper');
+        if (card) {
+          const laneName = findCardLane(card);
+          if (laneName !== null && !config.wipLanes.includes(laneName)) return null;
+        }
+      }
+
       const timestampString = getTimestampString(timeElement);
       const lastUpdated = parseServiceNowDateTime(timestampString);
       if (!lastUpdated) return null;
@@ -547,6 +574,55 @@
 
     function normalizeDateLabel(text) {
       return text.trim().replace(/\s*:\s*$/, '').toLocaleLowerCase();
+    }
+
+    // CSS selectors tried in order when searching for a lane/column title element.
+    // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+    const LANE_TITLE_SELECTORS = [
+      '.vtb-lane-header-title',
+      '.sn-board-header-title',
+      '.vtb-board-header-title',
+      '[class*="lane-header"] [class*="title"]',
+      '[class*="lane"] > [class*="header"] > [class*="title"]',
+    ];
+
+    // Returns the lane (column) name for a given card by walking up the DOM.
+    function findCardLane(card) {
+      let el = card.parentElement;
+      while (el && el !== document.body) {
+        for (const sel of LANE_TITLE_SELECTORS) {
+          try {
+            const found = el.querySelector(sel);
+            if (found) {
+              const text = found.textContent.trim();
+              if (text) return text;
+            }
+          } catch (_) {}
+        }
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    // Returns all unique lane names currently visible on the board.
+    function discoverLanes() {
+      const lanes = [];
+      for (const sel of LANE_TITLE_SELECTORS) {
+        try {
+          document.querySelectorAll(sel).forEach((el) => {
+            const text = el.textContent.trim();
+            if (text && !lanes.includes(text)) lanes.push(text);
+          });
+        } catch (_) {}
+      }
+      // Fallback: derive from cards if direct header query found nothing
+      if (lanes.length === 0) {
+        document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+          const lane = findCardLane(card);
+          if (lane && !lanes.includes(lane)) lanes.push(lane);
+        });
+      }
+      return lanes;
     }
 
     const DATE_LABELS = {

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,15 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <!--
-      Safari version: Google Fonts CDN link removed.
-      Safari extension pages apply a strict Content Security Policy that blocks
-      external stylesheet requests by default. System fonts are used instead.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
+      rel="stylesheet"
+    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: "Roboto", sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;
@@ -198,6 +197,23 @@
         color: #666;
         margin-top: 4px;
       }
+      .lane-checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 0;
+      }
+      .lane-checkbox-item input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .lane-checkbox-item label {
+        cursor: pointer;
+        font-weight: 400;
+        margin: 0;
+      }
     </style>
   </head>
   <body>
@@ -259,7 +275,7 @@
       </div>
       <div class="section-title">Last Updated Freshness Indicator</div>
       <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card's last
+        When enabled, a fresh or stale emoji appears beside the card’s last
         updated timestamp (bottom right corner of each VTB card). Set the
         threshold in days to split fresh vs. stale, and pick emojis; leaving
         them blank falls back to defaults.
@@ -312,6 +328,16 @@
             fall back to the default icons.
           </p>
         </div>
+        <div class="field-group" id="wipLanesSection" style="display:none;">
+          <label>WIP Lanes:</label>
+          <p class="field-help">
+            Check the lanes where the freshness indicator should appear. Leave
+            all unchecked to show on every card regardless of lane.
+          </p>
+          <div id="wipLanesList" style="margin-top: 8px;">
+            <!-- dynamically populated by options.js -->
+          </div>
+        </div>
         <div class="preview-card" id="updatePreview">
           <div class="preview-text" style="width:100%;">
             <div style="display:flex; gap:12px; align-items:center; justify-content:space-between;">
@@ -336,3 +362,4 @@
     <script src="options.js"></script>
   </body>
 </html>
+

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -1,6 +1,3 @@
-// Safari version: uses browser.storage.sync (Promise-based WebExtensions API)
-// instead of chrome.storage.sync (callback-based Chrome API).
-
 document.addEventListener('DOMContentLoaded', function () {
   const DEFAULT_UPDATE_THRESHOLD_DAYS = 6;
   const DEFAULT_UPDATE_INDICATOR = {
@@ -46,44 +43,43 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const wipLanesSection = document.getElementById('wipLanesSection');
+  const wipLanesList = document.getElementById('wipLanesList');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from browser.storage.sync (Safari/WebExtensions) or fallback to defaults.
+  // Load config from chrome.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage }
-      ).then(function (data) {
-        let cfg = data.vtbEnhancerConfig;
-        // Migrate old format { ageBands: [...] }
-        if (cfg && cfg.ageBands) {
-          cfg = { defaultConfig: cfg, boards: {} };
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(normalizeConfigStructure(cfg));
         }
-        callback(normalizeConfigStructure(cfg));
-      }).catch(function () {
-        callback(normalizeConfigStructure(defaultStorage));
-      });
+      );
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using browser.storage.sync.
+  // Save configuration using chrome.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
-        if (callback) callback();
-      }).catch(function () {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
       });
     } else {
@@ -180,6 +176,50 @@ document.addEventListener('DOMContentLoaded', function () {
     return { freshEmoji: fresh, staleEmoji: stale };
   }
 
+  function renderWipLanes(boardId) {
+    if (!boardId) {
+      wipLanesSection.style.display = 'none';
+      return;
+    }
+    const boardCfg = fullConfig.boards[boardId];
+    const lanes = (boardCfg && Array.isArray(boardCfg.lanes)) ? boardCfg.lanes : [];
+    const wipLanes = (boardCfg && Array.isArray(boardCfg.wipLanes)) ? boardCfg.wipLanes : [];
+
+    wipLanesList.innerHTML = '';
+    if (lanes.length === 0) {
+      const hint = document.createElement('p');
+      hint.className = 'field-help';
+      hint.textContent = 'No lanes discovered yet. Visit this board in ServiceNow, then return here to configure WIP lanes.';
+      wipLanesList.appendChild(hint);
+    } else {
+      lanes.forEach((lane) => {
+        const item = document.createElement('div');
+        item.className = 'lane-checkbox-item';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        const safeId = 'lane-' + lane.replace(/[^a-z0-9]/gi, '-');
+        cb.id = safeId;
+        cb.value = lane;
+        cb.checked = wipLanes.includes(lane);
+        const lbl = document.createElement('label');
+        lbl.htmlFor = safeId;
+        lbl.textContent = lane;
+        item.appendChild(cb);
+        item.appendChild(lbl);
+        wipLanesList.appendChild(item);
+      });
+    }
+    wipLanesSection.style.display = '';
+  }
+
+  function getWipLanesFromUI() {
+    const checked = [];
+    wipLanesList.querySelectorAll('input[type="checkbox"]:checked').forEach((cb) => {
+      checked.push(cb.value);
+    });
+    return checked;
+  }
+
   function toggleSettingsVisibility() {
     const showAge = ageBadgeToggle.checked;
     const showUpdate = updateIndicatorToggle.checked;
@@ -255,6 +295,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    renderWipLanes(currentBoardId);
   }
 
   function refreshTable() {
@@ -438,6 +480,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].wipLanes = getWipLanesFromUI();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -461,6 +504,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].wipLanes;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();


### PR DESCRIPTION
## Summary

Fixes #20. Freshness (stale/fresh) emojis were showing on every card regardless of its lane — making backlog items appear erroneously stale. This PR lets teams mark specific lanes as WIP so indicators only appear where they're meaningful.

**How it works:**

- The extension auto-discovers lane names each time the board loads and saves them to the board's config entry.
- In the options page, a new **WIP Lanes** checkbox list appears when a board-specific config is selected. Check any lanes that are "in progress"; leave all unchecked to keep current global behaviour.
- The freshness indicator is suppressed for cards in unchecked lanes; the age badge is unaffected.

**Changes:**

- `content.js` / `safari-extension/content.js`:
  - `LANE_TITLE_SELECTORS` — ranked list of CSS selectors for ServiceNow VTB column headers (multiple selectors because the exact class varies by SN version/theme)
  - `findCardLane(card)` — walks up the DOM from a card to find its column title
  - `discoverLanes()` — finds all unique lane names on the board at load time
  - `updateBoardInfo()` — persists discovered lanes to `cfg.boards[id].lanes` in storage
  - `computeUpdateIndicatorState()` — skips non-WIP cards when `wipLanes` is configured
  - `getConfig()` — normalises `wipLanes` and `lanes` to `[]` for each board entry

- `options.html` / `options.js` (both mirrored to `safari-extension/`):
  - New **WIP Lanes** section with checkboxes, hidden on the Default config view
  - Shows a "visit the board first" hint when no lanes have been discovered yet
  - `renderWipLanes()`, `getWipLanesFromUI()` — populate and read the checkbox list
  - Save and Reset both handle `wipLanes`

## Notes

- Lane detection uses DOM traversal with multiple selector fallbacks — exact class names vary across ServiceNow versions. If lanes don't appear in options after visiting a board, the selectors may need adjusting (open a follow-up issue).
- Cards that move between lanes during a session will have their indicator re-evaluated by the existing MutationObserver on the next attribute change.

## Manually tested

- Options page: WIP Lanes section hidden for Default, visible for a board-specific config
- "Visit the board first" hint shows when `lanes` is empty
- Checkboxes populate and persist correctly on save
- Unchecked-lane cards show no freshness emoji; checked-lane cards show normally
- Empty wipLanes (all unchecked) restores global behaviour