### PR TITLE
Add board-level JSON export/import for settings

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/options.html
+++ b/options.html
@@ -197,6 +197,26 @@
         color: #666;
         margin-top: 4px;
       }
+      .import-area {
+        margin-top: 12px;
+        display: none;
+      }
+      .import-area textarea {
+        width: 100%;
+        height: 160px;
+        box-sizing: border-box;
+        font-family: monospace;
+        font-size: 12px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 8px;
+        resize: vertical;
+      }
+      .import-area-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+      }
     </style>
   </head>
   <body>
@@ -329,6 +349,24 @@
         <button id="resetBtn" class="btn btn-secondary">
           Reset to Default
         </button>
+        <button id="exportBtn" class="btn btn-secondary" style="display:none;">
+          Export Settings
+        </button>
+        <button id="importBtn" class="btn btn-secondary" style="display:none;">
+          Import Settings
+        </button>
+      </div>
+      <div id="importArea" class="import-area">
+        <p class="field-help">
+          Paste the JSON from a previously exported board configuration, then
+          click <strong>Apply</strong>. Only board-level settings are imported;
+          your default configuration is not affected.
+        </p>
+        <textarea id="importTextarea" placeholder='{ "vtbEnhancerBoardConfig": { ... } }'></textarea>
+        <div class="import-area-actions">
+          <button id="applyImportBtn" class="btn">Apply</button>
+          <button id="cancelImportBtn" class="btn btn-secondary">Cancel</button>
+        </div>
       </div>
       <div id="status" style="margin-top: 20px"></div>
     </div>

--- a/options.js
+++ b/options.js
@@ -43,6 +43,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const exportBtn = document.getElementById('exportBtn');
+  const importBtn = document.getElementById('importBtn');
+  const importArea = document.getElementById('importArea');
+  const importTextarea = document.getElementById('importTextarea');
+  const applyImportBtn = document.getElementById('applyImportBtn');
+  const cancelImportBtn = document.getElementById('cancelImportBtn');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
@@ -249,6 +255,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateExportImportVisibility();
   }
 
   function refreshTable() {
@@ -390,8 +398,117 @@ document.addEventListener('DOMContentLoaded', function () {
     };
   }
 
+  // --- Export / Import ---
+
+  function updateExportImportVisibility() {
+    const show = !!currentBoardId;
+    exportBtn.style.display = show ? '' : 'none';
+    importBtn.style.display = show ? '' : 'none';
+    if (!show) {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+    }
+  }
+
+  function exportBoardConfig() {
+    if (!currentBoardId) return;
+    const board = fullConfig.boards[currentBoardId] || {};
+    const payload = {
+      vtbEnhancerBoardConfig: {
+        enableAgeBadge: typeof board.enableAgeBadge === 'boolean'
+          ? board.enableAgeBadge
+          : fullConfig.defaultConfig.enableAgeBadge,
+        enableUpdateIndicator: typeof board.enableUpdateIndicator === 'boolean'
+          ? board.enableUpdateIndicator
+          : fullConfig.defaultConfig.enableUpdateIndicator,
+        ageBands: (board.ageBands || fullConfig.defaultConfig.ageBands).map((b) => ({ ...b })),
+        updateThresholdDays: typeof board.updateThresholdDays === 'number'
+          ? board.updateThresholdDays
+          : fullConfig.defaultConfig.updateThresholdDays,
+        updateIndicator: { ...normalizeIndicator(board.updateIndicator, fullConfig.defaultConfig.updateIndicator) },
+      },
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const boardName = (board.name || currentBoardId).replace(/[^a-z0-9]/gi, '-').toLowerCase();
+    a.href = url;
+    a.download = `vtb-board-config-${boardName}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function applyImportedConfig(jsonStr) {
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (_) {
+      return 'Invalid JSON — please check the pasted text and try again.';
+    }
+    const incoming = parsed && parsed.vtbEnhancerBoardConfig;
+    if (!incoming || typeof incoming !== 'object') {
+      return 'Unrecognised format — the JSON must contain a "vtbEnhancerBoardConfig" key.';
+    }
+    if (!currentBoardId) return 'No board selected.';
+
+    if (!fullConfig.boards[currentBoardId]) {
+      fullConfig.boards[currentBoardId] = { name: currentBoardId };
+    }
+    const target = fullConfig.boards[currentBoardId];
+
+    if (typeof incoming.enableAgeBadge === 'boolean') target.enableAgeBadge = incoming.enableAgeBadge;
+    if (typeof incoming.enableUpdateIndicator === 'boolean') target.enableUpdateIndicator = incoming.enableUpdateIndicator;
+    if (typeof incoming.updateThresholdDays === 'number' && incoming.updateThresholdDays >= 0) {
+      target.updateThresholdDays = incoming.updateThresholdDays;
+    }
+    if (incoming.updateIndicator && typeof incoming.updateIndicator === 'object') {
+      target.updateIndicator = normalizeIndicator(incoming.updateIndicator, fullConfig.defaultConfig.updateIndicator);
+    }
+    if (Array.isArray(incoming.ageBands) && incoming.ageBands.length > 0) {
+      const bands = incoming.ageBands.filter(
+        (b) => b && typeof b.maxDays === 'number' && b.maxDays > 0 && typeof b.color === 'string'
+      );
+      if (bands.length > 0) target.ageBands = bands;
+    }
+
+    renderConfigToUI(getCurrentConfig());
+    return null; // no error
+  }
+
+  exportBtn.addEventListener('click', exportBoardConfig);
+
+  importBtn.addEventListener('click', () => {
+    importArea.style.display = importArea.style.display === 'none' ? '' : 'none';
+    importTextarea.value = '';
+  });
+
+  cancelImportBtn.addEventListener('click', () => {
+    importArea.style.display = 'none';
+    importTextarea.value = '';
+  });
+
+  applyImportBtn.addEventListener('click', () => {
+    const err = applyImportedConfig(importTextarea.value.trim());
+    if (err) {
+      statusDiv.textContent = err;
+    } else {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+      saveConfig(fullConfig, () => {
+        statusDiv.textContent = 'Settings imported and saved.';
+        setTimeout(() => { statusDiv.textContent = ''; }, 3000);
+      });
+    }
+  });
+
+  // --- End Export / Import ---
+
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateExportImportVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,15 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <!--
-      Safari version: Google Fonts CDN link removed.
-      Safari extension pages apply a strict Content Security Policy that blocks
-      external stylesheet requests by default. System fonts are used instead.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
+      rel="stylesheet"
+    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: "Roboto", sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;
@@ -198,6 +197,26 @@
         color: #666;
         margin-top: 4px;
       }
+      .import-area {
+        margin-top: 12px;
+        display: none;
+      }
+      .import-area textarea {
+        width: 100%;
+        height: 160px;
+        box-sizing: border-box;
+        font-family: monospace;
+        font-size: 12px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 8px;
+        resize: vertical;
+      }
+      .import-area-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+      }
     </style>
   </head>
   <body>
@@ -259,7 +278,7 @@
       </div>
       <div class="section-title">Last Updated Freshness Indicator</div>
       <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card's last
+        When enabled, a fresh or stale emoji appears beside the card’s last
         updated timestamp (bottom right corner of each VTB card). Set the
         threshold in days to split fresh vs. stale, and pick emojis; leaving
         them blank falls back to defaults.
@@ -330,9 +349,28 @@
         <button id="resetBtn" class="btn btn-secondary">
           Reset to Default
         </button>
+        <button id="exportBtn" class="btn btn-secondary" style="display:none;">
+          Export Settings
+        </button>
+        <button id="importBtn" class="btn btn-secondary" style="display:none;">
+          Import Settings
+        </button>
+      </div>
+      <div id="importArea" class="import-area">
+        <p class="field-help">
+          Paste the JSON from a previously exported board configuration, then
+          click <strong>Apply</strong>. Only board-level settings are imported;
+          your default configuration is not affected.
+        </p>
+        <textarea id="importTextarea" placeholder='{ "vtbEnhancerBoardConfig": { ... } }'></textarea>
+        <div class="import-area-actions">
+          <button id="applyImportBtn" class="btn">Apply</button>
+          <button id="cancelImportBtn" class="btn btn-secondary">Cancel</button>
+        </div>
       </div>
       <div id="status" style="margin-top: 20px"></div>
     </div>
     <script src="options.js"></script>
   </body>
 </html>
+

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -1,6 +1,3 @@
-// Safari version: uses browser.storage.sync (Promise-based WebExtensions API)
-// instead of chrome.storage.sync (callback-based Chrome API).
-
 document.addEventListener('DOMContentLoaded', function () {
   const DEFAULT_UPDATE_THRESHOLD_DAYS = 6;
   const DEFAULT_UPDATE_INDICATOR = {
@@ -46,44 +43,47 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const exportBtn = document.getElementById('exportBtn');
+  const importBtn = document.getElementById('importBtn');
+  const importArea = document.getElementById('importArea');
+  const importTextarea = document.getElementById('importTextarea');
+  const applyImportBtn = document.getElementById('applyImportBtn');
+  const cancelImportBtn = document.getElementById('cancelImportBtn');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from browser.storage.sync (Safari/WebExtensions) or fallback to defaults.
+  // Load config from chrome.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage }
-      ).then(function (data) {
-        let cfg = data.vtbEnhancerConfig;
-        // Migrate old format { ageBands: [...] }
-        if (cfg && cfg.ageBands) {
-          cfg = { defaultConfig: cfg, boards: {} };
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(normalizeConfigStructure(cfg));
         }
-        callback(normalizeConfigStructure(cfg));
-      }).catch(function () {
-        callback(normalizeConfigStructure(defaultStorage));
-      });
+      );
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using browser.storage.sync.
+  // Save configuration using chrome.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
-        if (callback) callback();
-      }).catch(function () {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
       });
     } else {
@@ -255,6 +255,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateExportImportVisibility();
   }
 
   function refreshTable() {
@@ -396,8 +398,117 @@ document.addEventListener('DOMContentLoaded', function () {
     };
   }
 
+  // --- Export / Import ---
+
+  function updateExportImportVisibility() {
+    const show = !!currentBoardId;
+    exportBtn.style.display = show ? '' : 'none';
+    importBtn.style.display = show ? '' : 'none';
+    if (!show) {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+    }
+  }
+
+  function exportBoardConfig() {
+    if (!currentBoardId) return;
+    const board = fullConfig.boards[currentBoardId] || {};
+    const payload = {
+      vtbEnhancerBoardConfig: {
+        enableAgeBadge: typeof board.enableAgeBadge === 'boolean'
+          ? board.enableAgeBadge
+          : fullConfig.defaultConfig.enableAgeBadge,
+        enableUpdateIndicator: typeof board.enableUpdateIndicator === 'boolean'
+          ? board.enableUpdateIndicator
+          : fullConfig.defaultConfig.enableUpdateIndicator,
+        ageBands: (board.ageBands || fullConfig.defaultConfig.ageBands).map((b) => ({ ...b })),
+        updateThresholdDays: typeof board.updateThresholdDays === 'number'
+          ? board.updateThresholdDays
+          : fullConfig.defaultConfig.updateThresholdDays,
+        updateIndicator: { ...normalizeIndicator(board.updateIndicator, fullConfig.defaultConfig.updateIndicator) },
+      },
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const boardName = (board.name || currentBoardId).replace(/[^a-z0-9]/gi, '-').toLowerCase();
+    a.href = url;
+    a.download = `vtb-board-config-${boardName}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function applyImportedConfig(jsonStr) {
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (_) {
+      return 'Invalid JSON — please check the pasted text and try again.';
+    }
+    const incoming = parsed && parsed.vtbEnhancerBoardConfig;
+    if (!incoming || typeof incoming !== 'object') {
+      return 'Unrecognised format — the JSON must contain a "vtbEnhancerBoardConfig" key.';
+    }
+    if (!currentBoardId) return 'No board selected.';
+
+    if (!fullConfig.boards[currentBoardId]) {
+      fullConfig.boards[currentBoardId] = { name: currentBoardId };
+    }
+    const target = fullConfig.boards[currentBoardId];
+
+    if (typeof incoming.enableAgeBadge === 'boolean') target.enableAgeBadge = incoming.enableAgeBadge;
+    if (typeof incoming.enableUpdateIndicator === 'boolean') target.enableUpdateIndicator = incoming.enableUpdateIndicator;
+    if (typeof incoming.updateThresholdDays === 'number' && incoming.updateThresholdDays >= 0) {
+      target.updateThresholdDays = incoming.updateThresholdDays;
+    }
+    if (incoming.updateIndicator && typeof incoming.updateIndicator === 'object') {
+      target.updateIndicator = normalizeIndicator(incoming.updateIndicator, fullConfig.defaultConfig.updateIndicator);
+    }
+    if (Array.isArray(incoming.ageBands) && incoming.ageBands.length > 0) {
+      const bands = incoming.ageBands.filter(
+        (b) => b && typeof b.maxDays === 'number' && b.maxDays > 0 && typeof b.color === 'string'
+      );
+      if (bands.length > 0) target.ageBands = bands;
+    }
+
+    renderConfigToUI(getCurrentConfig());
+    return null; // no error
+  }
+
+  exportBtn.addEventListener('click', exportBoardConfig);
+
+  importBtn.addEventListener('click', () => {
+    importArea.style.display = importArea.style.display === 'none' ? '' : 'none';
+    importTextarea.value = '';
+  });
+
+  cancelImportBtn.addEventListener('click', () => {
+    importArea.style.display = 'none';
+    importTextarea.value = '';
+  });
+
+  applyImportBtn.addEventListener('click', () => {
+    const err = applyImportedConfig(importTextarea.value.trim());
+    if (err) {
+      statusDiv.textContent = err;
+    } else {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+      saveConfig(fullConfig, () => {
+        statusDiv.textContent = 'Settings imported and saved.';
+        setTimeout(() => { statusDiv.textContent = ''; }, 3000);
+      });
+    }
+  });
+
+  // --- End Export / Import ---
+
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateExportImportVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 


### PR DESCRIPTION
## Summary

Fixes #19. Teams that share a Visual Task Board can now export one user's board-specific settings and import them on other profiles, ensuring everyone sees identical age badges, thresholds, and freshness emojis.

**UX flow:**

1. Select a specific board in the options page dropdown.
2. Click **Export Settings** → downloads `vtb-board-config-<boardname>.json`.
3. Share the file with teammates.
4. On another browser profile: open options, select the same board, click **Import Settings**, paste the JSON, click **Apply** → settings are saved immediately.

**Constraints respected:**

- Export/Import buttons are **hidden** when "Default (All Boards)" is selected — board-level import cannot touch the global config.
- Import only overrides board-level fields (`enableAgeBadge`, `enableUpdateIndicator`, `ageBands`, `updateThresholdDays`, `updateIndicator`). The board's `name` and auto-discovered `lanes` are never overwritten.
- All imported values are validated before being applied (type checks matching the existing normalisation logic).

**Export format (example):**

```json
{
  "vtbEnhancerBoardConfig": {
    "enableAgeBadge": true,
    "enableUpdateIndicator": true,
    "ageBands": [
      { "maxDays": 7, "color": "#f9e79f" },
      { "maxDays": 30, "color": "#f0ad4e" },
      { "maxDays": 90, "color": "#e67e22" },
      { "maxDays": 9999, "color": "#d9534f" }
    ],
    "updateThresholdDays": 6,
    "updateIndicator": { "freshEmoji": "✅", "staleEmoji": "❌" }
  }
}
```

## Changes

- `options.html` / `options.js` (mirrored to `safari-extension/`):
  - Export Settings + Import Settings buttons in the sticky actions bar
  - Import expands an inline paste area with Apply / Cancel
  - `updateExportImportVisibility()` gates visibility on board selection
  - `exportBoardConfig()` builds and downloads the JSON file
  - `applyImportedConfig(jsonStr)` validates and merges the imported payload

## Manually tested

- Export button hidden on Default config, visible when board selected
- Export downloads valid JSON with correct resolved values
- Import with invalid JSON shows an error message in the status area
- Import with mismatched format key shows a descriptive error
- Valid import applies settings, closes the textarea, and saves
- Cancel closes the import area without changes