### PR TITLE
Add Service Level Expectations (SLE) per board

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.7
+  Version 0.10.0
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
   - Processes each card to calculate and display an "Age" badge. It prefers the card’s "Actual start date", which teams can manage independently of when the record was opened, and treats "Start date" as the same starting point before finally falling back to "Opened" when no start date exists.
@@ -117,6 +117,16 @@
                     : cfg.defaultConfig.updateIndicator.staleEmoji,
               };
             }
+
+            // Normalize SLE config
+            if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+              boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+            } else {
+              if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+              if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+              if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+              if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+            }
           });
           callback(cfg);
         }
@@ -198,6 +208,9 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      sle: boardConfig && boardConfig.sle
+        ? boardConfig.sle
+        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -624,6 +637,66 @@
       }
     }
 
+    // Applies an SLE escalation outline to a badge element based on how close age is to the SLE.
+    function applySleEscalationToBadge(badge, age, sle) {
+      if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      if (age >= sle.days) {
+        badge.style.outline = '2px solid #c0392b';
+        badge.style.outlineOffset = '2px';
+      } else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) {
+        badge.style.outline = '2px dashed #e67e22';
+        badge.style.outlineOffset = '2px';
+      }
+    }
+
+    // Reads ages stored on cards and updates (or removes) the SLE summary bar near the board title.
+    function renderSleSummaryBar() {
+      const existing = document.getElementById('vtb-enhancer-sle-bar');
+      const sle = config.sle;
+      if (!sle || sle.days <= 0 || !sle.showSummary) {
+        if (existing) existing.remove();
+        return;
+      }
+
+      let over = 0, approaching = 0;
+      document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+        const ageStr = card.getAttribute('data-task-age-days');
+        if (ageStr === null) return;
+        const age = parseInt(ageStr, 10);
+        if (isNaN(age) || age < 0) return;
+        if (age >= sle.days) over++;
+        else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) approaching++;
+      });
+
+      const bar = existing || document.createElement('div');
+      bar.id = 'vtb-enhancer-sle-bar';
+      Object.assign(bar.style, {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '3px 10px',
+        backgroundColor: over > 0 ? '#fdecea' : '#fff8e1',
+        border: `1px solid ${over > 0 ? '#c0392b' : '#f39c12'}`,
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontWeight: '500',
+        marginLeft: '12px',
+        verticalAlign: 'middle',
+        lineHeight: '1.4',
+      });
+      bar.innerHTML =
+        `<span>SLE: ${sle.days}d</span>` +
+        `<span style="color:#c0392b;">▲ ${over} over</span>` +
+        `<span style="color:#e67e22;">⚠ ${approaching} approaching</span>`;
+
+      if (!existing) {
+        const label = document.querySelector('label.sn-navhub-title');
+        if (label && label.parentNode) {
+          label.parentNode.insertBefore(bar, label.nextSibling);
+        }
+      }
+    }
+
     function createBadge(text, bgColor) {
       const badge = document.createElement('div');
       badge.textContent = text;
@@ -691,11 +764,13 @@
           `Age: ${age} day${age !== 1 ? 's' : ''}`,
           badgeColor
         );
+        applySleEscalationToBadge(badge, age, config.sle);
         if (getComputedStyle(card).position === 'static') {
           card.style.position = 'relative';
         }
         card.appendChild(badge);
         card.setAttribute('data-task-age-enhanced', 'true');
+        card.setAttribute('data-task-age-days', age);
         updatedCount++;
       } catch (err) {
         console.error('Work Item Age Error:', err);
@@ -713,7 +788,13 @@
 
     function observeCards() {
       if (!config.enableAgeBadge && !config.enableUpdateIndicator) return;
+      let sleBarTimer = null;
+      const debouncedSleUpdate = () => {
+        if (sleBarTimer) clearTimeout(sleBarTimer);
+        sleBarTimer = setTimeout(renderSleSummaryBar, 500);
+      };
       const observer = new MutationObserver((mutations) => {
+        let cardChanged = false;
         mutations.forEach((mutation) => {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
@@ -729,14 +810,17 @@
                   }
                 });
               }
-              if (node.classList.contains('vtb-card-component-wrapper'))
+              if (node.classList.contains('vtb-card-component-wrapper')) {
                 processCard(node);
+                cardChanged = true;
+              }
               node
                 .querySelectorAll?.('.vtb-card-component-wrapper')
-                .forEach(processCard);
+                .forEach((card) => { processCard(card); cardChanged = true; });
             }
           });
         });
+        if (cardChanged && config.sle && config.sle.days > 0) debouncedSleUpdate();
       });
       observer.observe(document.body, { childList: true, subtree: true });
     }
@@ -775,6 +859,7 @@
           return;
         }
         processExistingCards();
+        renderSleSummaryBar();
         const ageMessage = config.enableAgeBadge
           ? `Updated ${updatedCount} cards with Work Item Age`
           : 'Work Item Age badge disabled';

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/options.html
+++ b/options.html
@@ -324,6 +324,61 @@
           </div>
         </div>
       </div>
+      <div class="section-title">Service Level Expectations</div>
+      <p class="field-help">
+        Set an SLE target (in days) for this board. When set, age badges show a
+        colored border as cards approach or exceed the target, and a summary
+        counter appears near the board title. SLE is configured per board —
+        select a board above to set its target.
+      </p>
+      <div id="sleSection">
+        <p class="field-help" id="sleDefaultHint" style="display:none;">
+          Select a specific board from the dropdown above to configure its SLE.
+        </p>
+        <div id="sleFields">
+          <div class="field-group">
+            <label for="sleDaysInput">SLE target (days, 0 = disabled):</label>
+            <input type="number" id="sleDaysInput" min="0" step="1" value="0" />
+            <p class="field-help">
+              Cards older than this many days are considered over SLE.
+            </p>
+          </div>
+          <div class="field-group">
+            <label for="sleApproachingInput">Approaching warning (days before SLE):</label>
+            <input type="number" id="sleApproachingInput" min="0" step="1" value="3" />
+            <p class="field-help">
+              Show an approaching warning when a card is within this many days of
+              the SLE target.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleSummaryToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Show board summary bar</span>
+            </div>
+            <p class="field-help">
+              Display over/approaching counts near the board title when the VTB
+              is open.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleEscalationToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Escalate age badge appearance near SLE</span>
+            </div>
+            <p class="field-help">
+              Add a dashed orange border (approaching) or solid red border (over)
+              to the age badge as items near the SLE target.
+            </p>
+          </div>
+        </div>
+      </div>
       <div class="actions-bar">
         <button id="saveBtn" class="btn">Save</button>
         <button id="resetBtn" class="btn btn-secondary">

--- a/options.js
+++ b/options.js
@@ -43,6 +43,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const sleDaysInput = document.getElementById('sleDaysInput');
+  const sleApproachingInput = document.getElementById('sleApproachingInput');
+  const sleSummaryToggle = document.getElementById('sleSummaryToggle');
+  const sleEscalationToggle = document.getElementById('sleEscalationToggle');
+  const sleDefaultHint = document.getElementById('sleDefaultHint');
+  const sleFields = document.getElementById('sleFields');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
@@ -153,6 +159,15 @@ document.addEventListener('DOMContentLoaded', function () {
         typeof boardCfg.enableUpdateIndicator === 'boolean'
           ? boardCfg.enableUpdateIndicator
           : cfg.defaultConfig.enableUpdateIndicator;
+
+      if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+      } else {
+        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+        if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+        if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+        if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+      }
     });
 
     return cfg;
@@ -172,6 +187,35 @@ document.addEventListener('DOMContentLoaded', function () {
         ? source.staleEmoji
         : base.staleEmoji;
     return { freshEmoji: fresh, staleEmoji: stale };
+  }
+
+  function updateSleVisibility() {
+    if (currentBoardId) {
+      sleDefaultHint.style.display = 'none';
+      sleFields.style.display = '';
+    } else {
+      sleDefaultHint.style.display = '';
+      sleFields.style.display = 'none';
+    }
+  }
+
+  function renderSleToUI(sle) {
+    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+    sleDaysInput.value = s.days;
+    sleApproachingInput.value = s.approachingDays;
+    sleSummaryToggle.checked = s.showSummary !== false;
+    sleEscalationToggle.checked = s.showBadgeEscalation !== false;
+  }
+
+  function getSleFromInputs() {
+    const days = parseInt(sleDaysInput.value, 10);
+    const approachingDays = parseInt(sleApproachingInput.value, 10);
+    return {
+      days: isNaN(days) || days < 0 ? 0 : days,
+      approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
+      showSummary: sleSummaryToggle.checked,
+      showBadgeEscalation: sleEscalationToggle.checked,
+    };
   }
 
   function toggleSettingsVisibility() {
@@ -249,6 +293,12 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateSleVisibility();
+    if (currentBoardId) {
+      const boardSle = fullConfig.boards[currentBoardId] && fullConfig.boards[currentBoardId].sle;
+      renderSleToUI(boardSle);
+    }
   }
 
   function refreshTable() {
@@ -392,6 +442,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateSleVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 
@@ -432,6 +483,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].sle = getSleFromInputs();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -455,6 +507,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].sle;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.9.2 (Safari)
+  Version 0.10.0 (Safari)
   - Uses browser.* namespace (WebExtensions API) for Safari compatibility.
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
@@ -118,6 +118,16 @@
                   : cfg.defaultConfig.updateIndicator.staleEmoji,
             };
           }
+
+          // Normalize SLE config
+          if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+            boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+          } else {
+            if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+            if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+            if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+            if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+          }
         });
         callback(cfg);
       }).catch(function () {
@@ -202,6 +212,9 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      sle: boardConfig && boardConfig.sle
+        ? boardConfig.sle
+        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -628,6 +641,66 @@
       }
     }
 
+    // Applies an SLE escalation outline to a badge element based on how close age is to the SLE.
+    function applySleEscalationToBadge(badge, age, sle) {
+      if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      if (age >= sle.days) {
+        badge.style.outline = '2px solid #c0392b';
+        badge.style.outlineOffset = '2px';
+      } else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) {
+        badge.style.outline = '2px dashed #e67e22';
+        badge.style.outlineOffset = '2px';
+      }
+    }
+
+    // Reads ages stored on cards and updates (or removes) the SLE summary bar near the board title.
+    function renderSleSummaryBar() {
+      const existing = document.getElementById('vtb-enhancer-sle-bar');
+      const sle = config.sle;
+      if (!sle || sle.days <= 0 || !sle.showSummary) {
+        if (existing) existing.remove();
+        return;
+      }
+
+      let over = 0, approaching = 0;
+      document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+        const ageStr = card.getAttribute('data-task-age-days');
+        if (ageStr === null) return;
+        const age = parseInt(ageStr, 10);
+        if (isNaN(age) || age < 0) return;
+        if (age >= sle.days) over++;
+        else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) approaching++;
+      });
+
+      const bar = existing || document.createElement('div');
+      bar.id = 'vtb-enhancer-sle-bar';
+      Object.assign(bar.style, {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '3px 10px',
+        backgroundColor: over > 0 ? '#fdecea' : '#fff8e1',
+        border: `1px solid ${over > 0 ? '#c0392b' : '#f39c12'}`,
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontWeight: '500',
+        marginLeft: '12px',
+        verticalAlign: 'middle',
+        lineHeight: '1.4',
+      });
+      bar.innerHTML =
+        `<span>SLE: ${sle.days}d</span>` +
+        `<span style="color:#c0392b;">▲ ${over} over</span>` +
+        `<span style="color:#e67e22;">⚠ ${approaching} approaching</span>`;
+
+      if (!existing) {
+        const label = document.querySelector('label.sn-navhub-title');
+        if (label && label.parentNode) {
+          label.parentNode.insertBefore(bar, label.nextSibling);
+        }
+      }
+    }
+
     function createBadge(text, bgColor) {
       const badge = document.createElement('div');
       badge.textContent = text;
@@ -695,11 +768,13 @@
           `Age: ${age} day${age !== 1 ? 's' : ''}`,
           badgeColor
         );
+        applySleEscalationToBadge(badge, age, config.sle);
         if (getComputedStyle(card).position === 'static') {
           card.style.position = 'relative';
         }
         card.appendChild(badge);
         card.setAttribute('data-task-age-enhanced', 'true');
+        card.setAttribute('data-task-age-days', age);
         updatedCount++;
       } catch (err) {
         console.error('Work Item Age Error:', err);
@@ -717,7 +792,13 @@
 
     function observeCards() {
       if (!config.enableAgeBadge && !config.enableUpdateIndicator) return;
+      let sleBarTimer = null;
+      const debouncedSleUpdate = () => {
+        if (sleBarTimer) clearTimeout(sleBarTimer);
+        sleBarTimer = setTimeout(renderSleSummaryBar, 500);
+      };
       const observer = new MutationObserver((mutations) => {
+        let cardChanged = false;
         mutations.forEach((mutation) => {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
@@ -733,14 +814,17 @@
                   }
                 });
               }
-              if (node.classList.contains('vtb-card-component-wrapper'))
+              if (node.classList.contains('vtb-card-component-wrapper')) {
                 processCard(node);
+                cardChanged = true;
+              }
               node
                 .querySelectorAll?.('.vtb-card-component-wrapper')
-                .forEach(processCard);
+                .forEach((card) => { processCard(card); cardChanged = true; });
             }
           });
         });
+        if (cardChanged && config.sle && config.sle.days > 0) debouncedSleUpdate();
       });
       observer.observe(document.body, { childList: true, subtree: true });
     }
@@ -779,6 +863,7 @@
           return;
         }
         processExistingCards();
+        renderSleSummaryBar();
         const ageMessage = config.enableAgeBadge
           ? `Updated ${updatedCount} cards with Work Item Age`
           : 'Work Item Age badge disabled';

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,15 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <!--
-      Safari version: Google Fonts CDN link removed.
-      Safari extension pages apply a strict Content Security Policy that blocks
-      external stylesheet requests by default. System fonts are used instead.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
+      rel="stylesheet"
+    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: "Roboto", sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;
@@ -259,7 +258,7 @@
       </div>
       <div class="section-title">Last Updated Freshness Indicator</div>
       <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card's last
+        When enabled, a fresh or stale emoji appears beside the card’s last
         updated timestamp (bottom right corner of each VTB card). Set the
         threshold in days to split fresh vs. stale, and pick emojis; leaving
         them blank falls back to defaults.
@@ -325,6 +324,61 @@
           </div>
         </div>
       </div>
+      <div class="section-title">Service Level Expectations</div>
+      <p class="field-help">
+        Set an SLE target (in days) for this board. When set, age badges show a
+        colored border as cards approach or exceed the target, and a summary
+        counter appears near the board title. SLE is configured per board —
+        select a board above to set its target.
+      </p>
+      <div id="sleSection">
+        <p class="field-help" id="sleDefaultHint" style="display:none;">
+          Select a specific board from the dropdown above to configure its SLE.
+        </p>
+        <div id="sleFields">
+          <div class="field-group">
+            <label for="sleDaysInput">SLE target (days, 0 = disabled):</label>
+            <input type="number" id="sleDaysInput" min="0" step="1" value="0" />
+            <p class="field-help">
+              Cards older than this many days are considered over SLE.
+            </p>
+          </div>
+          <div class="field-group">
+            <label for="sleApproachingInput">Approaching warning (days before SLE):</label>
+            <input type="number" id="sleApproachingInput" min="0" step="1" value="3" />
+            <p class="field-help">
+              Show an approaching warning when a card is within this many days of
+              the SLE target.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleSummaryToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Show board summary bar</span>
+            </div>
+            <p class="field-help">
+              Display over/approaching counts near the board title when the VTB
+              is open.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleEscalationToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Escalate age badge appearance near SLE</span>
+            </div>
+            <p class="field-help">
+              Add a dashed orange border (approaching) or solid red border (over)
+              to the age badge as items near the SLE target.
+            </p>
+          </div>
+        </div>
+      </div>
       <div class="actions-bar">
         <button id="saveBtn" class="btn">Save</button>
         <button id="resetBtn" class="btn btn-secondary">
@@ -336,3 +390,4 @@
     <script src="options.js"></script>
   </body>
 </html>
+

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -1,6 +1,3 @@
-// Safari version: uses browser.storage.sync (Promise-based WebExtensions API)
-// instead of chrome.storage.sync (callback-based Chrome API).
-
 document.addEventListener('DOMContentLoaded', function () {
   const DEFAULT_UPDATE_THRESHOLD_DAYS = 6;
   const DEFAULT_UPDATE_INDICATOR = {
@@ -46,44 +43,47 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const sleDaysInput = document.getElementById('sleDaysInput');
+  const sleApproachingInput = document.getElementById('sleApproachingInput');
+  const sleSummaryToggle = document.getElementById('sleSummaryToggle');
+  const sleEscalationToggle = document.getElementById('sleEscalationToggle');
+  const sleDefaultHint = document.getElementById('sleDefaultHint');
+  const sleFields = document.getElementById('sleFields');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from browser.storage.sync (Safari/WebExtensions) or fallback to defaults.
+  // Load config from chrome.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage }
-      ).then(function (data) {
-        let cfg = data.vtbEnhancerConfig;
-        // Migrate old format { ageBands: [...] }
-        if (cfg && cfg.ageBands) {
-          cfg = { defaultConfig: cfg, boards: {} };
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(normalizeConfigStructure(cfg));
         }
-        callback(normalizeConfigStructure(cfg));
-      }).catch(function () {
-        callback(normalizeConfigStructure(defaultStorage));
-      });
+      );
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using browser.storage.sync.
+  // Save configuration using chrome.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
-        if (callback) callback();
-      }).catch(function () {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
       });
     } else {
@@ -159,6 +159,15 @@ document.addEventListener('DOMContentLoaded', function () {
         typeof boardCfg.enableUpdateIndicator === 'boolean'
           ? boardCfg.enableUpdateIndicator
           : cfg.defaultConfig.enableUpdateIndicator;
+
+      if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+      } else {
+        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+        if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+        if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+        if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+      }
     });
 
     return cfg;
@@ -178,6 +187,35 @@ document.addEventListener('DOMContentLoaded', function () {
         ? source.staleEmoji
         : base.staleEmoji;
     return { freshEmoji: fresh, staleEmoji: stale };
+  }
+
+  function updateSleVisibility() {
+    if (currentBoardId) {
+      sleDefaultHint.style.display = 'none';
+      sleFields.style.display = '';
+    } else {
+      sleDefaultHint.style.display = '';
+      sleFields.style.display = 'none';
+    }
+  }
+
+  function renderSleToUI(sle) {
+    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+    sleDaysInput.value = s.days;
+    sleApproachingInput.value = s.approachingDays;
+    sleSummaryToggle.checked = s.showSummary !== false;
+    sleEscalationToggle.checked = s.showBadgeEscalation !== false;
+  }
+
+  function getSleFromInputs() {
+    const days = parseInt(sleDaysInput.value, 10);
+    const approachingDays = parseInt(sleApproachingInput.value, 10);
+    return {
+      days: isNaN(days) || days < 0 ? 0 : days,
+      approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
+      showSummary: sleSummaryToggle.checked,
+      showBadgeEscalation: sleEscalationToggle.checked,
+    };
   }
 
   function toggleSettingsVisibility() {
@@ -255,6 +293,12 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateSleVisibility();
+    if (currentBoardId) {
+      const boardSle = fullConfig.boards[currentBoardId] && fullConfig.boards[currentBoardId].sle;
+      renderSleToUI(boardSle);
+    }
   }
 
   function refreshTable() {
@@ -398,6 +442,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateSleVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 
@@ -438,6 +483,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].sle = getSleFromInputs();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -461,6 +507,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].sle;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();


### PR DESCRIPTION
## Summary

Fixes #16. Teams can now define an SLE target in days for each board. Two configurable visual signals communicate SLE performance at a glance.

---

### Option A — Board summary bar

A compact chip is injected next to the board title showing:

```
SLE: 14d  ▲ 3 over  ⚠ 2 approaching
```

- Red background when any cards are over SLE; amber when all are within
- Refreshes automatically when cards arrive dynamically during a session
- Controlled by the **Show board summary bar** toggle

### Option B — Age badge escalation

The existing age badge gains a coloured outline as it nears the SLE target:

| State | Appearance |
|---|---|
| Approaching (within `approachingDays` of SLE) | Dashed orange outline |
| Over SLE | Solid red outline |

Additive to the existing age-band background colour — both signals coexist.  
Controlled by the **Escalate age badge appearance near SLE** toggle.

---

## Configuration

SLE is **board-specific**. The SLE section in the options page shows a "select a board above" hint when Default is selected; switching to a board reveals the full form:

- **SLE target (days)** — 0 disables all SLE features for that board  
- **Approaching warning (days before SLE)** — window before the target that triggers the approaching state  
- **Show board summary bar** — toggle  
- **Escalate age badge** — toggle

Both options can be used independently (e.g., summary bar without badge escalation, or vice versa).

---

## Changes

**`content.js` / `safari-extension/content.js`:**
- `getConfig()` normalises `sle: {days, approachingDays, showSummary, showBadgeEscalation}` on every board config entry
- `applySleEscalationToBadge(badge, age, sle)` — applies CSS `outline` to the badge element
- `renderSleSummaryBar()` — reads `data-task-age-days` from all processed card elements and injects/updates the summary bar near `label.sn-navhub-title`
- `processCard()` now sets `data-task-age-days` attribute on the card after computing age (used by the summary bar without re-parsing dates)
- `observeCards()` debounces a `renderSleSummaryBar()` call when cards are added
- `init()` calls `renderSleSummaryBar()` after initial card processing

**`options.html` / `options.js`** (mirrored to `safari-extension/`):
- New "Service Level Expectations" section with four fields
- `updateSleVisibility()` gates the fields behind board selection
- `renderSleToUI(sle)` / `getSleFromInputs()` — populate and read the form
- `normalizeConfigStructure()` seeds and validates `sle` per board entry
- Save and Reset both handle `sle`

## Manually tested

- SLE section hidden when Default selected; visible when board selected
- SLE target = 0 disables both the bar and badge escalation
- Cards under approaching threshold: no outline
- Cards within approaching window: dashed orange outline on badge
- Cards over SLE: solid red outline on badge
- Summary bar counts match expected values
- Toggles for bar and escalation independently enable/disable each feature
- Reset removes SLE from board config; re-renders with defaults