### PR TITLE
Fix freshness indicator hidden by sn-time-ago opacity CSS

### DIFF
--- a/content.js
+++ b/content.js
@@ -125,8 +125,9 @@
               boardCfg.lanes = [];
             }
             if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-              boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+              boardCfg.sle = { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
             } else {
+              if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = true;
               if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
               if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
               if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
@@ -205,31 +206,31 @@
 
   // Returns the lane (column) name for a given card by walking up the DOM.
   //
-  // Key constraint: we use querySelectorAll (not querySelector) and only accept
-  // the result when exactly ONE title element is found within the current ancestor.
-  // This prevents the common failure mode where the walk-up reaches a board-level
-  // container that holds ALL lane headers — querySelector would return the first
-  // lane in the DOM (e.g. "Backlog") for every card regardless of their actual lane.
-  // When multiple titles are found, we break the inner loop (stop trying selectors
-  // at this level) and continue to the parent, eventually falling back to positional
-  // matching if no single-lane ancestor is ever found.
+  // Only the most specific selector (.vtb-lane-header-title) is used for the
+  // walk-up uniqueness check. Broader selectors like [class*="title"] match
+  // multiple elements per lane (the div, the form, the label, any input) so the
+  // length===1 check would never succeed even when we're inside a single-lane
+  // ancestor — causing false "multiple lanes" breaks and falling through to the
+  // positional fallback for every card.
+  //
+  // The walk-up stops and returns the lane name as soon as exactly one
+  // .vtb-lane-header-title is found under the current ancestor (i.e. we're
+  // inside one lane's container). If that number exceeds one we've climbed above
+  // the lane boundary and fall back to positional matching.
   function findCardLane(card) {
+    const primarySel = LANE_TITLE_SELECTORS[0]; // '.vtb-lane-header-title'
     let el = card.parentElement;
     while (el && el !== document.body) {
-      for (const sel of LANE_TITLE_SELECTORS) {
-        try {
-          const matches = el.querySelectorAll(sel);
-          if (matches.length === 1) {
-            const text = getLaneTitleText(matches[0]);
-            if (text) return text;
-          } else if (matches.length > 1) {
-            // This ancestor spans multiple lanes — stop testing selectors here
-            // and move up to the next parent.
-            break;
-          }
-          // length === 0: no title in this subtree via this selector; try next
-        } catch (_) {}
-      }
+      try {
+        const matches = el.querySelectorAll(primarySel);
+        if (matches.length === 1) {
+          const text = getLaneTitleText(matches[0]);
+          if (text) return text;
+        } else if (matches.length > 1) {
+          break; // climbed above lane boundary — multiple headers visible
+        }
+        // length === 0: header not in this subtree yet; keep walking up
+      } catch (_) {}
       el = el.parentElement;
     }
     // Walk-up could not isolate a single-lane ancestor — fall back to positional
@@ -357,7 +358,7 @@
       wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
       sle: boardConfig && boardConfig.sle
         ? boardConfig.sle
-        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
+        : { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -550,11 +551,13 @@
 
     function computeUpdateIndicatorState(timeElement) {
       // When WIP lanes are configured, suppress the indicator on non-WIP cards.
+      // Cards whose lane cannot be determined (null) are also suppressed — when
+      // WIP mode is on we default to "not a WIP lane" rather than showing on all.
       if (config.wipLanes && config.wipLanes.length > 0) {
         const card = timeElement.closest('.vtb-card-component-wrapper');
         if (card) {
           const laneName = findCardLane(card);
-          if (laneName !== null && !config.wipLanes.includes(laneName)) return null;
+          if (!config.wipLanes.includes(laneName)) return null;
         }
       }
 
@@ -866,7 +869,7 @@
 
     // Applies an SLE escalation outline and emoji prefix to a badge based on age vs SLE target.
     function applySleEscalationToBadge(badge, age, sle) {
-      if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      if (!sle || sle.enabled === false || sle.days <= 0 || !sle.showBadgeEscalation) return;
       const approachingEmoji = sle.approachingEmoji || '⚠️';
       const breachedEmoji = sle.breachedEmoji || '🔴';
       if (age >= sle.days) {
@@ -884,7 +887,7 @@
     function renderSleSummaryBar() {
       const existing = document.getElementById('vtb-enhancer-sle-bar');
       const sle = config.sle;
-      if (!sle || sle.days <= 0 || !sle.showSummary) {
+      if (!sle || sle.enabled === false || sle.days <= 0 || !sle.showSummary) {
         if (existing) existing.remove();
         return;
       }
@@ -1057,7 +1060,7 @@
             }
           });
         });
-        if (cardChanged && config.sle && config.sle.days > 0) debouncedSleUpdate();
+        if (cardChanged && config.sle && config.sle.enabled !== false && config.sle.days > 0) debouncedSleUpdate();
       });
       observer.observe(document.body, { childList: true, subtree: true });
     }

--- a/content.js
+++ b/content.js
@@ -905,6 +905,10 @@
         if (age === null) return;
         card.setAttribute('data-task-age-days', age);
         if (!config.enableAgeBadge) return;
+        if (config.wipLanes && config.wipLanes.length > 0) {
+          const laneName = findCardLane(card);
+          if (laneName !== null && !config.wipLanes.includes(laneName)) return;
+        }
         const badgeColor = getBadgeColor(age);
         const badge = createBadge(
           `Age: ${age} day${age !== 1 ? 's' : ''}`,

--- a/content.js
+++ b/content.js
@@ -491,15 +491,15 @@
     }
 
     function removeExistingUpdateIndicator(timeElement) {
-      const existingIndicator = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator'
-      );
-      if (existingIndicator) existingIndicator.remove();
-
-      const existingSrText = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator-text'
-      );
-      if (existingSrText) existingSrText.remove();
+      // The indicator lives on the card wrapper (not inside the time element) so
+      // that it remains visible regardless of lane-specific CSS applied to the
+      // sn-time-ago subtree.
+      const card = timeElement.closest('.vtb-card-component-wrapper');
+      if (card) {
+        card.querySelectorAll(
+          '.vtb-enhancer-update-indicator, .vtb-enhancer-update-indicator-text'
+        ).forEach((el) => el.remove());
+      }
     }
 
     function getIndicatorEmojis() {
@@ -591,17 +591,21 @@
 
     function applyUpdateIndicator(timeElement) {
       const state = computeUpdateIndicatorState(timeElement);
-      const existingIndicator = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator'
-      );
-      const existingSrText = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator-text'
-      );
+
+      // Render the indicator directly on the card wrapper, not inside the
+      // sn-time-ago subtree. Some lanes (e.g. those that hide their timestamp
+      // footer until card hover) apply CSS to sn-time-ago that makes any
+      // injected children invisible until the hover state activates. Placing
+      // the indicator on the card wrapper — the same host element used by the
+      // age badge — ensures it is always visible.
+      const card = timeElement.closest('.vtb-card-component-wrapper');
+
+      const existingIndicator = card && card.querySelector('.vtb-enhancer-update-indicator');
+      const existingSrText = card && card.querySelector('.vtb-enhancer-update-indicator-text');
 
       if (!state) {
-        if (existingIndicator || existingSrText) {
-          removeExistingUpdateIndicator(timeElement);
-        }
+        if (existingIndicator) existingIndicator.remove();
+        if (existingSrText) existingSrText.remove();
         return;
       }
 
@@ -614,50 +618,44 @@
         return;
       }
 
-      removeExistingUpdateIndicator(timeElement);
+      if (existingIndicator) existingIndicator.remove();
+      if (existingSrText) existingSrText.remove();
+
+      if (!card) return;
+      if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
 
       const indicatorSpan = document.createElement('span');
       indicatorSpan.className = 'vtb-enhancer-update-indicator';
       indicatorSpan.setAttribute('aria-hidden', 'true');
-      indicatorSpan.style.marginLeft = '4px';
       indicatorSpan.textContent = state.emoji;
+      Object.assign(indicatorSpan.style, {
+        position: 'absolute',
+        bottom: '2px',
+        right: '6px',
+        zIndex: '1001',
+        fontSize: '13px',
+        lineHeight: '1',
+        pointerEvents: 'none',
+      });
 
       const srSpan = document.createElement('span');
-      srSpan.className = 'sr-only vtb-enhancer-update-indicator-text';
-      srSpan.textContent = state.srMessage;
+      srSpan.className = 'vtb-enhancer-update-indicator-text';
+      // sr-only inline equivalent so Bootstrap's class isn't required
+      srSpan.setAttribute('aria-label', state.srMessage);
+      Object.assign(srSpan.style, {
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: '0',
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0,0,0,0)',
+        whiteSpace: 'nowrap',
+        border: '0',
+      });
 
-      const visibleSpan = Array.from(timeElement.children).find(
-        (child) =>
-          child.nodeType === Node.ELEMENT_NODE &&
-          child.tagName === 'SPAN' &&
-          !child.classList.contains('sr-only') &&
-          !child.classList.contains('vtb-enhancer-update-indicator') &&
-          !child.classList.contains('vtb-enhancer-update-indicator-text')
-      );
-
-      const srOnlyReference = Array.from(timeElement.children).find(
-        (child) =>
-          child.classList &&
-          child.classList.contains('sr-only') &&
-          !child.classList.contains('vtb-enhancer-update-indicator-text')
-      );
-
-      if (visibleSpan && typeof visibleSpan.after === 'function') {
-        visibleSpan.after(indicatorSpan);
-      } else if (srOnlyReference && srOnlyReference.parentNode) {
-        srOnlyReference.parentNode.insertBefore(
-          indicatorSpan,
-          srOnlyReference
-        );
-      } else {
-        timeElement.appendChild(indicatorSpan);
-      }
-
-      if (srOnlyReference && srOnlyReference.parentNode) {
-        srOnlyReference.parentNode.insertBefore(srSpan, srOnlyReference);
-      } else {
-        indicatorSpan.after(srSpan);
-      }
+      card.appendChild(indicatorSpan);
+      card.appendChild(srSpan);
     }
 
     function detachTimeObserver(timeElement) {

--- a/content.js
+++ b/content.js
@@ -204,25 +204,37 @@
   }
 
   // Returns the lane (column) name for a given card by walking up the DOM.
-  // If the walk-up finds no header (e.g. lane headers and card lists are in
-  // parallel DOM branches), falls back to positional matching.
+  //
+  // Key constraint: we use querySelectorAll (not querySelector) and only accept
+  // the result when exactly ONE title element is found within the current ancestor.
+  // This prevents the common failure mode where the walk-up reaches a board-level
+  // container that holds ALL lane headers — querySelector would return the first
+  // lane in the DOM (e.g. "Backlog") for every card regardless of their actual lane.
+  // When multiple titles are found, we break the inner loop (stop trying selectors
+  // at this level) and continue to the parent, eventually falling back to positional
+  // matching if no single-lane ancestor is ever found.
   function findCardLane(card) {
     let el = card.parentElement;
     while (el && el !== document.body) {
       for (const sel of LANE_TITLE_SELECTORS) {
         try {
-          const found = el.querySelector(sel);
-          if (found) {
-            const text = getLaneTitleText(found);
+          const matches = el.querySelectorAll(sel);
+          if (matches.length === 1) {
+            const text = getLaneTitleText(matches[0]);
             if (text) return text;
+          } else if (matches.length > 1) {
+            // This ancestor spans multiple lanes — stop testing selectors here
+            // and move up to the next parent.
+            break;
           }
+          // length === 0: no title in this subtree via this selector; try next
         } catch (_) {}
       }
       el = el.parentElement;
     }
-    // Positional fallback: find the lane header whose horizontal centre is
-    // closest to this card's horizontal centre (works even when headers and
-    // cards live in separate DOM subtrees).
+    // Walk-up could not isolate a single-lane ancestor — fall back to positional
+    // matching (works for boards where headers and card columns are in parallel
+    // DOM branches, e.g. sticky-header layouts).
     return findCardLaneByPosition(card);
   }
 

--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.7
+  Version 0.10.0
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
   - Processes each card to calculate and display an "Age" badge. It prefers the card’s "Actual start date", which teams can manage independently of when the record was opened, and treats "Start date" as the same starting point before finally falling back to "Opened" when no start date exists.
@@ -117,6 +117,13 @@
                     : cfg.defaultConfig.updateIndicator.staleEmoji,
               };
             }
+
+            if (!Array.isArray(boardCfg.wipLanes)) {
+              boardCfg.wipLanes = [];
+            }
+            if (!Array.isArray(boardCfg.lanes)) {
+              boardCfg.lanes = [];
+            }
           });
           callback(cfg);
         }
@@ -148,12 +155,21 @@
     const label = document.querySelector('label.sn-navhub-title');
     if (!label) return;
     const name = label.textContent.trim();
+    const discoveredLanes = discoverLanes();
     if (!cfg.boards[boardId]) {
-      cfg.boards[boardId] = { name: name };
+      cfg.boards[boardId] = { name, lanes: discoveredLanes };
       saveConfig(cfg);
-    } else if (cfg.boards[boardId].name !== name) {
-      cfg.boards[boardId].name = name;
-      saveConfig(cfg);
+    } else {
+      let changed = false;
+      if (cfg.boards[boardId].name !== name) {
+        cfg.boards[boardId].name = name;
+        changed = true;
+      }
+      if (discoveredLanes.length > 0) {
+        cfg.boards[boardId].lanes = discoveredLanes;
+        changed = true;
+      }
+      if (changed) saveConfig(cfg);
     }
   }
 
@@ -198,6 +214,8 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      // wipLanes: empty array means show on all cards; non-empty restricts to named lanes only.
+      wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -323,6 +341,15 @@
     }
 
     function computeUpdateIndicatorState(timeElement) {
+      // When WIP lanes are configured, suppress the indicator on non-WIP cards.
+      if (config.wipLanes && config.wipLanes.length > 0) {
+        const card = timeElement.closest('.vtb-card-component-wrapper');
+        if (card) {
+          const laneName = findCardLane(card);
+          if (laneName !== null && !config.wipLanes.includes(laneName)) return null;
+        }
+      }
+
       const timestampString = getTimestampString(timeElement);
       const lastUpdated = parseServiceNowDateTime(timestampString);
       if (!lastUpdated) return null;
@@ -543,6 +570,55 @@
 
     function normalizeDateLabel(text) {
       return text.trim().replace(/\s*:\s*$/, '').toLocaleLowerCase();
+    }
+
+    // CSS selectors tried in order when searching for a lane/column title element.
+    // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+    const LANE_TITLE_SELECTORS = [
+      '.vtb-lane-header-title',
+      '.sn-board-header-title',
+      '.vtb-board-header-title',
+      '[class*="lane-header"] [class*="title"]',
+      '[class*="lane"] > [class*="header"] > [class*="title"]',
+    ];
+
+    // Returns the lane (column) name for a given card by walking up the DOM.
+    function findCardLane(card) {
+      let el = card.parentElement;
+      while (el && el !== document.body) {
+        for (const sel of LANE_TITLE_SELECTORS) {
+          try {
+            const found = el.querySelector(sel);
+            if (found) {
+              const text = found.textContent.trim();
+              if (text) return text;
+            }
+          } catch (_) {}
+        }
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    // Returns all unique lane names currently visible on the board.
+    function discoverLanes() {
+      const lanes = [];
+      for (const sel of LANE_TITLE_SELECTORS) {
+        try {
+          document.querySelectorAll(sel).forEach((el) => {
+            const text = el.textContent.trim();
+            if (text && !lanes.includes(text)) lanes.push(text);
+          });
+        } catch (_) {}
+      }
+      // Fallback: derive from cards if direct header query found nothing
+      if (lanes.length === 0) {
+        document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+          const lane = findCardLane(card);
+          if (lane && !lanes.includes(lane)) lanes.push(lane);
+        });
+      }
+      return lanes;
     }
 
     const DATE_LABELS = {

--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.7
+  Version 0.10.0
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
   - Processes each card to calculate and display an "Age" badge. It prefers the card’s "Actual start date", which teams can manage independently of when the record was opened, and treats "Start date" as the same starting point before finally falling back to "Opened" when no start date exists.
@@ -117,6 +117,16 @@
                     : cfg.defaultConfig.updateIndicator.staleEmoji,
               };
             }
+
+            // Normalize SLE config
+            if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+              boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+            } else {
+              if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+              if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+              if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+              if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+            }
           });
           callback(cfg);
         }
@@ -198,6 +208,9 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      sle: boardConfig && boardConfig.sle
+        ? boardConfig.sle
+        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -624,6 +637,66 @@
       }
     }
 
+    // Applies an SLE escalation outline to a badge element based on how close age is to the SLE.
+    function applySleEscalationToBadge(badge, age, sle) {
+      if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      if (age >= sle.days) {
+        badge.style.outline = '2px solid #c0392b';
+        badge.style.outlineOffset = '2px';
+      } else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) {
+        badge.style.outline = '2px dashed #e67e22';
+        badge.style.outlineOffset = '2px';
+      }
+    }
+
+    // Reads ages stored on cards and updates (or removes) the SLE summary bar near the board title.
+    function renderSleSummaryBar() {
+      const existing = document.getElementById('vtb-enhancer-sle-bar');
+      const sle = config.sle;
+      if (!sle || sle.days <= 0 || !sle.showSummary) {
+        if (existing) existing.remove();
+        return;
+      }
+
+      let over = 0, approaching = 0;
+      document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+        const ageStr = card.getAttribute('data-task-age-days');
+        if (ageStr === null) return;
+        const age = parseInt(ageStr, 10);
+        if (isNaN(age) || age < 0) return;
+        if (age >= sle.days) over++;
+        else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) approaching++;
+      });
+
+      const bar = existing || document.createElement('div');
+      bar.id = 'vtb-enhancer-sle-bar';
+      Object.assign(bar.style, {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '3px 10px',
+        backgroundColor: over > 0 ? '#fdecea' : '#fff8e1',
+        border: `1px solid ${over > 0 ? '#c0392b' : '#f39c12'}`,
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontWeight: '500',
+        marginLeft: '12px',
+        verticalAlign: 'middle',
+        lineHeight: '1.4',
+      });
+      bar.innerHTML =
+        `<span>SLE: ${sle.days}d</span>` +
+        `<span style="color:#c0392b;">▲ ${over} over</span>` +
+        `<span style="color:#e67e22;">⚠ ${approaching} approaching</span>`;
+
+      if (!existing) {
+        const label = document.querySelector('label.sn-navhub-title');
+        if (label && label.parentNode) {
+          label.parentNode.insertBefore(bar, label.nextSibling);
+        }
+      }
+    }
+
     function createBadge(text, bgColor) {
       const badge = document.createElement('div');
       badge.textContent = text;
@@ -691,11 +764,13 @@
           `Age: ${age} day${age !== 1 ? 's' : ''}`,
           badgeColor
         );
+        applySleEscalationToBadge(badge, age, config.sle);
         if (getComputedStyle(card).position === 'static') {
           card.style.position = 'relative';
         }
         card.appendChild(badge);
         card.setAttribute('data-task-age-enhanced', 'true');
+        card.setAttribute('data-task-age-days', age);
         updatedCount++;
       } catch (err) {
         console.error('Work Item Age Error:', err);
@@ -713,7 +788,13 @@
 
     function observeCards() {
       if (!config.enableAgeBadge && !config.enableUpdateIndicator) return;
+      let sleBarTimer = null;
+      const debouncedSleUpdate = () => {
+        if (sleBarTimer) clearTimeout(sleBarTimer);
+        sleBarTimer = setTimeout(renderSleSummaryBar, 500);
+      };
       const observer = new MutationObserver((mutations) => {
+        let cardChanged = false;
         mutations.forEach((mutation) => {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
@@ -729,14 +810,17 @@
                   }
                 });
               }
-              if (node.classList.contains('vtb-card-component-wrapper'))
+              if (node.classList.contains('vtb-card-component-wrapper')) {
                 processCard(node);
+                cardChanged = true;
+              }
               node
                 .querySelectorAll?.('.vtb-card-component-wrapper')
-                .forEach(processCard);
+                .forEach((card) => { processCard(card); cardChanged = true; });
             }
           });
         });
+        if (cardChanged && config.sle && config.sle.days > 0) debouncedSleUpdate();
       });
       observer.observe(document.body, { childList: true, subtree: true });
     }
@@ -775,6 +859,7 @@
           return;
         }
         processExistingCards();
+        renderSleSummaryBar();
         const ageMessage = config.enableAgeBadge
           ? `Updated ${updatedCount} cards with Work Item Age`
           : 'Work Item Age badge disabled';

--- a/content.js
+++ b/content.js
@@ -156,6 +156,55 @@
     }
   }
 
+  // CSS selectors tried in order when searching for a lane/column title element.
+  // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+  const LANE_TITLE_SELECTORS = [
+    '.vtb-lane-header-title',
+    '.sn-board-header-title',
+    '.vtb-board-header-title',
+    '[class*="lane-header"] [class*="title"]',
+    '[class*="lane"] > [class*="header"] > [class*="title"]',
+  ];
+
+  // Returns the lane (column) name for a given card by walking up the DOM.
+  function findCardLane(card) {
+    let el = card.parentElement;
+    while (el && el !== document.body) {
+      for (const sel of LANE_TITLE_SELECTORS) {
+        try {
+          const found = el.querySelector(sel);
+          if (found) {
+            const text = found.textContent.trim();
+            if (text) return text;
+          }
+        } catch (_) {}
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  // Returns all unique lane names currently visible on the board.
+  function discoverLanes() {
+    const lanes = [];
+    for (const sel of LANE_TITLE_SELECTORS) {
+      try {
+        document.querySelectorAll(sel).forEach((el) => {
+          const text = el.textContent.trim();
+          if (text && !lanes.includes(text)) lanes.push(text);
+        });
+      } catch (_) {}
+    }
+    // Fallback: derive from cards if direct header query found nothing
+    if (lanes.length === 0) {
+      document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+        const lane = findCardLane(card);
+        if (lane && !lanes.includes(lane)) lanes.push(lane);
+      });
+    }
+    return lanes;
+  }
+
   function updateBoardInfo(cfg) {
     if (!boardId) return;
     // Prevent prototype pollution
@@ -647,55 +696,6 @@
 
     function normalizeDateLabel(text) {
       return text.trim().replace(/\s*:\s*$/, '').toLocaleLowerCase();
-    }
-
-    // CSS selectors tried in order when searching for a lane/column title element.
-    // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
-    const LANE_TITLE_SELECTORS = [
-      '.vtb-lane-header-title',
-      '.sn-board-header-title',
-      '.vtb-board-header-title',
-      '[class*="lane-header"] [class*="title"]',
-      '[class*="lane"] > [class*="header"] > [class*="title"]',
-    ];
-
-    // Returns the lane (column) name for a given card by walking up the DOM.
-    function findCardLane(card) {
-      let el = card.parentElement;
-      while (el && el !== document.body) {
-        for (const sel of LANE_TITLE_SELECTORS) {
-          try {
-            const found = el.querySelector(sel);
-            if (found) {
-              const text = found.textContent.trim();
-              if (text) return text;
-            }
-          } catch (_) {}
-        }
-        el = el.parentElement;
-      }
-      return null;
-    }
-
-    // Returns all unique lane names currently visible on the board.
-    function discoverLanes() {
-      const lanes = [];
-      for (const sel of LANE_TITLE_SELECTORS) {
-        try {
-          document.querySelectorAll(sel).forEach((el) => {
-            const text = el.textContent.trim();
-            if (text && !lanes.includes(text)) lanes.push(text);
-          });
-        } catch (_) {}
-      }
-      // Fallback: derive from cards if direct header query found nothing
-      if (lanes.length === 0) {
-        document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
-          const lane = findCardLane(card);
-          if (lane && !lanes.includes(lane)) lanes.push(lane);
-        });
-      }
-      return lanes;
     }
 
     const DATE_LABELS = {

--- a/content.js
+++ b/content.js
@@ -491,15 +491,15 @@
     }
 
     function removeExistingUpdateIndicator(timeElement) {
-      // The indicator lives on the card wrapper (not inside the time element) so
-      // that it remains visible regardless of lane-specific CSS applied to the
-      // sn-time-ago subtree.
-      const card = timeElement.closest('.vtb-card-component-wrapper');
-      if (card) {
-        card.querySelectorAll(
-          '.vtb-enhancer-update-indicator, .vtb-enhancer-update-indicator-text'
-        ).forEach((el) => el.remove());
-      }
+      const existingIndicator = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator'
+      );
+      if (existingIndicator) existingIndicator.remove();
+
+      const existingSrText = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator-text'
+      );
+      if (existingSrText) existingSrText.remove();
     }
 
     function getIndicatorEmojis() {
@@ -591,21 +591,17 @@
 
     function applyUpdateIndicator(timeElement) {
       const state = computeUpdateIndicatorState(timeElement);
-
-      // Render the indicator directly on the card wrapper, not inside the
-      // sn-time-ago subtree. Some lanes (e.g. those that hide their timestamp
-      // footer until card hover) apply CSS to sn-time-ago that makes any
-      // injected children invisible until the hover state activates. Placing
-      // the indicator on the card wrapper — the same host element used by the
-      // age badge — ensures it is always visible.
-      const card = timeElement.closest('.vtb-card-component-wrapper');
-
-      const existingIndicator = card && card.querySelector('.vtb-enhancer-update-indicator');
-      const existingSrText = card && card.querySelector('.vtb-enhancer-update-indicator-text');
+      const existingIndicator = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator'
+      );
+      const existingSrText = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator-text'
+      );
 
       if (!state) {
-        if (existingIndicator) existingIndicator.remove();
-        if (existingSrText) existingSrText.remove();
+        if (existingIndicator || existingSrText) {
+          removeExistingUpdateIndicator(timeElement);
+        }
         return;
       }
 
@@ -618,44 +614,50 @@
         return;
       }
 
-      if (existingIndicator) existingIndicator.remove();
-      if (existingSrText) existingSrText.remove();
-
-      if (!card) return;
-      if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
+      removeExistingUpdateIndicator(timeElement);
 
       const indicatorSpan = document.createElement('span');
       indicatorSpan.className = 'vtb-enhancer-update-indicator';
       indicatorSpan.setAttribute('aria-hidden', 'true');
+      indicatorSpan.style.marginLeft = '4px';
       indicatorSpan.textContent = state.emoji;
-      Object.assign(indicatorSpan.style, {
-        position: 'absolute',
-        bottom: '2px',
-        right: '6px',
-        zIndex: '1001',
-        fontSize: '13px',
-        lineHeight: '1',
-        pointerEvents: 'none',
-      });
 
       const srSpan = document.createElement('span');
-      srSpan.className = 'vtb-enhancer-update-indicator-text';
-      // sr-only inline equivalent so Bootstrap's class isn't required
-      srSpan.setAttribute('aria-label', state.srMessage);
-      Object.assign(srSpan.style, {
-        position: 'absolute',
-        width: '1px',
-        height: '1px',
-        padding: '0',
-        margin: '-1px',
-        overflow: 'hidden',
-        clip: 'rect(0,0,0,0)',
-        whiteSpace: 'nowrap',
-        border: '0',
-      });
+      srSpan.className = 'sr-only vtb-enhancer-update-indicator-text';
+      srSpan.textContent = state.srMessage;
 
-      card.appendChild(indicatorSpan);
-      card.appendChild(srSpan);
+      const visibleSpan = Array.from(timeElement.children).find(
+        (child) =>
+          child.nodeType === Node.ELEMENT_NODE &&
+          child.tagName === 'SPAN' &&
+          !child.classList.contains('sr-only') &&
+          !child.classList.contains('vtb-enhancer-update-indicator') &&
+          !child.classList.contains('vtb-enhancer-update-indicator-text')
+      );
+
+      const srOnlyReference = Array.from(timeElement.children).find(
+        (child) =>
+          child.classList &&
+          child.classList.contains('sr-only') &&
+          !child.classList.contains('vtb-enhancer-update-indicator-text')
+      );
+
+      if (visibleSpan && typeof visibleSpan.after === 'function') {
+        visibleSpan.after(indicatorSpan);
+      } else if (srOnlyReference && srOnlyReference.parentNode) {
+        srOnlyReference.parentNode.insertBefore(
+          indicatorSpan,
+          srOnlyReference
+        );
+      } else {
+        timeElement.appendChild(indicatorSpan);
+      }
+
+      if (srOnlyReference && srOnlyReference.parentNode) {
+        srOnlyReference.parentNode.insertBefore(srSpan, srOnlyReference);
+      } else {
+        indicatorSpan.after(srSpan);
+      }
     }
 
     function detachTimeObserver(timeElement) {

--- a/content.js
+++ b/content.js
@@ -125,12 +125,14 @@
               boardCfg.lanes = [];
             }
             if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-              boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+              boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
             } else {
               if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
               if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
               if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
               if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+              if (!boardCfg.sle.approachingEmoji || typeof boardCfg.sle.approachingEmoji !== 'string') boardCfg.sle.approachingEmoji = '⚠️';
+              if (!boardCfg.sle.breachedEmoji || typeof boardCfg.sle.breachedEmoji !== 'string') boardCfg.sle.breachedEmoji = '🔴';
             }
           });
           callback(cfg);
@@ -166,6 +168,14 @@
     '[class*="lane"] > [class*="header"] > [class*="title"]',
   ];
 
+  // Strips trailing card-count badges from lane header text so stored names and
+  // runtime names stay in sync even when card counts change (e.g. "In Progress (5)" → "In Progress").
+  function normalizeLaneName(text) {
+    // Prefer text from direct text nodes only (avoids child badge elements entirely).
+    // Falls back to stripping the common "(N)" suffix pattern.
+    return text.replace(/\s*\(\d+\)\s*$/, '').trim();
+  }
+
   // Returns the lane (column) name for a given card by walking up the DOM.
   function findCardLane(card) {
     let el = card.parentElement;
@@ -174,7 +184,7 @@
         try {
           const found = el.querySelector(sel);
           if (found) {
-            const text = found.textContent.trim();
+            const text = normalizeLaneName(found.textContent.trim());
             if (text) return text;
           }
         } catch (_) {}
@@ -190,7 +200,7 @@
     for (const sel of LANE_TITLE_SELECTORS) {
       try {
         document.querySelectorAll(sel).forEach((el) => {
-          const text = el.textContent.trim();
+          const text = normalizeLaneName(el.textContent.trim());
           if (text && !lanes.includes(text)) lanes.push(text);
         });
       } catch (_) {}
@@ -275,7 +285,7 @@
       wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
       sle: boardConfig && boardConfig.sle
         ? boardConfig.sle
-        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
+        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -782,13 +792,17 @@
       }
     }
 
-    // Applies an SLE escalation outline to a badge element based on how close age is to the SLE.
+    // Applies an SLE escalation outline and emoji prefix to a badge based on age vs SLE target.
     function applySleEscalationToBadge(badge, age, sle) {
       if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      const approachingEmoji = sle.approachingEmoji || '⚠️';
+      const breachedEmoji = sle.breachedEmoji || '🔴';
       if (age >= sle.days) {
+        badge.textContent = `${breachedEmoji} ${badge.textContent}`;
         badge.style.outline = '2px solid #c0392b';
         badge.style.outlineOffset = '2px';
       } else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) {
+        badge.textContent = `${approachingEmoji} ${badge.textContent}`;
         badge.style.outline = '2px dashed #e67e22';
         badge.style.outlineOffset = '2px';
       }
@@ -903,13 +917,19 @@
         if (!startDate) return;
         const age = calculateDaysDiff(startDate);
         if (age === null) return;
-        card.setAttribute('data-task-age-days', age);
+        card.setAttribute('data-task-age-days', age); // Always set for SLE tracking (renderSleSummaryBar skips negative ages)
         if (!config.enableAgeBadge) return;
+        if (age < 0) {
+          // Work hasn't started yet — show how many days until the start date.
+          const badge = createBadge(`Starts in ${Math.abs(age)}d`, '#95a5a6');
+          if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
+          card.appendChild(badge);
+          card.setAttribute('data-task-age-enhanced', 'true');
+          updatedCount++;
+          return;
+        }
         const badgeColor = getBadgeColor(age);
-        const badge = createBadge(
-          `Age: ${age} day${age !== 1 ? 's' : ''}`,
-          badgeColor
-        );
+        const badge = createBadge(`${age}d`, badgeColor);
         applySleEscalationToBadge(badge, age, config.sle);
         if (getComputedStyle(card).position === 'static') {
           card.style.position = 'relative';

--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.7
+  Version 0.9.6
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
   - Processes each card to calculate and display an "Age" badge. It prefers the card’s "Actual start date", which teams can manage independently of when the record was opened, and treats "Start date" as the same starting point before finally falling back to "Opened" when no start date exists.
@@ -221,9 +221,66 @@
     const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
     function calculateDaysDiff(dateStr) {
-      const d = new Date(dateStr);
-      if (isNaN(d)) return null;
+      const d = parseDisplayedDate(dateStr);
+      if (!d) return null;
       return Math.floor((Date.now() - d.getTime()) / MS_PER_DAY);
+    }
+
+    // Determines whether the browser locale uses day-first ordering (DD/MM vs MM/DD).
+    // ServiceNow respects user locale settings; browser language is the best proxy available.
+    function isDayFirstLocale() {
+      const lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+      // Only en-US and a handful of others use month-first; default to day-first for safety.
+      return !/^en-us|^en-ca|^en-au/.test(lang) || lang === '';
+    }
+
+    // Parses a date string as displayed in a ServiceNow card field, which may be localized
+    // (e.g. "15.03.2024" in German, "03/15/2024" in US English, "15/03/2024" in UK).
+    // Falls through to parseServiceNowDateTime for ISO/internal format strings.
+    function parseDisplayedDate(dateStr) {
+      if (!dateStr || typeof dateStr !== 'string') return null;
+      const trimmed = dateStr.trim();
+
+      // ISO / ServiceNow internal format first (locale-independent)
+      const snParsed = parseServiceNowDateTime(trimmed);
+      if (snParsed) return snParsed;
+
+      // DD.MM.YYYY or DD.MM.YYYY HH:MM:SS (German, Austrian, Russian, etc.)
+      const dotMatch = trimmed.match(
+        /^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/
+      );
+      if (dotMatch) {
+        const [, dd, mm, yyyy, hh = '0', mi = '0', ss = '0'] = dotMatch;
+        const d = new Date(+yyyy, +mm - 1, +dd, +hh, +mi, +ss);
+        if (!isNaN(d)) return d;
+      }
+
+      // DD-MM-YYYY or MM-DD-YYYY with time component (hyphens, locale-detected)
+      // Note: YYYY-MM-DD is already handled by parseServiceNowDateTime above.
+      const hyphenMatch = trimmed.match(
+        /^(\d{1,2})-(\d{1,2})-(\d{4})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/
+      );
+      if (hyphenMatch) {
+        const [, a, b, yyyy, hh = '0', mi = '0', ss = '0'] = hyphenMatch;
+        const [dd, mm] = +a > 12 || isDayFirstLocale() ? [+a, +b] : [+b, +a];
+        const d = new Date(+yyyy, mm - 1, dd, +hh, +mi, +ss);
+        if (!isNaN(d)) return d;
+      }
+
+      // DD/MM/YYYY or MM/DD/YYYY with optional time (locale-detected for ambiguous cases)
+      const slashMatch = trimmed.match(
+        /^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/
+      );
+      if (slashMatch) {
+        const [, a, b, yyyy, hh = '0', mi = '0', ss = '0'] = slashMatch;
+        const [dd, mm] = +a > 12 || isDayFirstLocale() ? [+a, +b] : [+b, +a];
+        const d = new Date(+yyyy, mm - 1, dd, +hh, +mi, +ss);
+        if (!isNaN(d)) return d;
+      }
+
+      // "15 Mar 2024" or "March 15, 2024" — let the engine handle these
+      const fallback = new Date(trimmed);
+      return isNaN(fallback) ? null : fallback;
     }
 
     function parseServiceNowDateTime(dateStr) {
@@ -259,8 +316,15 @@
         if (!isNaN(base)) return base;
       }
 
-      const fallback = new Date(trimmed);
-      return isNaN(fallback) ? null : fallback;
+      // YYYY-MM-DD date-only (no time component)
+      const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      if (dateOnlyMatch) {
+        const [, year, month, day] = dateOnlyMatch.map(Number);
+        const d = new Date(year, month - 1, day);
+        if (!isNaN(d)) return d;
+      }
+
+      return null;
     }
 
     function removeExistingUpdateIndicator(timeElement) {
@@ -572,7 +636,12 @@
         );
         if (spans.length < 2) continue;
 
-        const value = spans[1].textContent.trim();
+        const valueSpan = spans[1];
+        // Prefer raw ISO value from data attributes when available — avoids locale-format issues.
+        const value =
+          valueSpan.getAttribute('data-value') ||
+          valueSpan.getAttribute('data-raw-value') ||
+          valueSpan.textContent.trim();
         if (!value) continue;
 
         const normalizedLabel = normalizeDateLabel(spans[0].textContent);

--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.10.0
+  Version 1.0.0
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
   - Processes each card to calculate and display an "Age" badge. It prefers the card’s "Actual start date", which teams can manage independently of when the record was opened, and treats "Start date" as the same starting point before finally falling back to "Opened" when no start date exists.

--- a/content.js
+++ b/content.js
@@ -159,7 +159,7 @@
   }
 
   // CSS selectors tried in order when searching for a lane/column title element.
-  // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+  // ServiceNow VTB renders lanes as columns; the title is in a header child element.
   const LANE_TITLE_SELECTORS = [
     '.vtb-lane-header-title',
     '.sn-board-header-title',
@@ -168,15 +168,44 @@
     '[class*="lane"] > [class*="header"] > [class*="title"]',
   ];
 
-  // Strips trailing card-count badges from lane header text so stored names and
-  // runtime names stay in sync even when card counts change (e.g. "In Progress (5)" → "In Progress").
-  function normalizeLaneName(text) {
-    // Prefer text from direct text nodes only (avoids child badge elements entirely).
-    // Falls back to stripping the common "(N)" suffix pattern.
-    return text.replace(/\s*\(\d+\)\s*$/, '').trim();
+  // Extracts the lane name text from a lane-title container element.
+  //
+  // ServiceNow VTB uses an AngularJS form pattern inside .vtb-lane-header-title:
+  //   <div class="vtb-lane-header-title">
+  //     <form data-original-title="In Flight" class="vtb-lane-title ...">
+  //       <label class="ng-binding ...">In Flight</label>
+  //       <input value="In Flight">
+  //     </form>
+  //   </div>
+  //
+  // The card count lives in a separate sibling div (.vtb-lane-header-count) and
+  // never appears inside the title element itself.
+  //
+  // However, AngularJS directives such as sn-tooltip-basic and sn-focus-input can
+  // inject hidden helper spans/elements inside the form, which pollute textContent.
+  // To get a clean, stable lane name we prefer these sources in order:
+  //   1. The inner <label> textContent — AngularJS keeps this bound exactly to the
+  //      lane name (ng-binding) with no extra injected text.
+  //   2. data-original-title on the <form> — set by sn-tooltip-basic to the lane name.
+  //   3. Normalized full textContent of the container as a last resort.
+  function getLaneTitleText(el) {
+    const label = el.querySelector('label');
+    if (label) {
+      const t = label.textContent.trim();
+      if (t) return t;
+    }
+    const formEl = el.matches && el.matches('form') ? el : el.querySelector('form');
+    if (formEl) {
+      const attr = formEl.getAttribute('data-original-title');
+      if (attr && attr.trim()) return attr.trim();
+    }
+    // Strip trailing "(N)" count patterns as a fallback safety measure
+    return el.textContent.trim().replace(/\s*\(\d+\)\s*$/, '').trim();
   }
 
   // Returns the lane (column) name for a given card by walking up the DOM.
+  // If the walk-up finds no header (e.g. lane headers and card lists are in
+  // parallel DOM branches), falls back to positional matching.
   function findCardLane(card) {
     let el = card.parentElement;
     while (el && el !== document.body) {
@@ -184,14 +213,42 @@
         try {
           const found = el.querySelector(sel);
           if (found) {
-            const text = normalizeLaneName(found.textContent.trim());
+            const text = getLaneTitleText(found);
             if (text) return text;
           }
         } catch (_) {}
       }
       el = el.parentElement;
     }
-    return null;
+    // Positional fallback: find the lane header whose horizontal centre is
+    // closest to this card's horizontal centre (works even when headers and
+    // cards live in separate DOM subtrees).
+    return findCardLaneByPosition(card);
+  }
+
+  // Positional lane-name lookup: aligns card x-position with header x-position.
+  function findCardLaneByPosition(card) {
+    try {
+      const cardRect = card.getBoundingClientRect();
+      if (cardRect.width === 0 && cardRect.height === 0) return null;
+      const cardCenterX = cardRect.left + cardRect.width / 2;
+      let closestName = null;
+      let minDist = Infinity;
+      for (const sel of LANE_TITLE_SELECTORS) {
+        document.querySelectorAll(sel).forEach((titleEl) => {
+          const name = getLaneTitleText(titleEl);
+          if (!name) return;
+          const r = titleEl.getBoundingClientRect();
+          if (r.width === 0 && r.height === 0) return;
+          const dist = Math.abs((r.left + r.width / 2) - cardCenterX);
+          if (dist < minDist) { minDist = dist; closestName = name; }
+        });
+        if (closestName !== null) break;
+      }
+      return closestName;
+    } catch (_) {
+      return null;
+    }
   }
 
   // Returns all unique lane names currently visible on the board.
@@ -200,12 +257,15 @@
     for (const sel of LANE_TITLE_SELECTORS) {
       try {
         document.querySelectorAll(sel).forEach((el) => {
-          const text = normalizeLaneName(el.textContent.trim());
+          const text = getLaneTitleText(el);
           if (text && !lanes.includes(text)) lanes.push(text);
         });
       } catch (_) {}
+      // Use the first selector that finds anything to avoid duplicates from
+      // broader selectors matching the same elements.
+      if (lanes.length > 0) break;
     }
-    // Fallback: derive from cards if direct header query found nothing
+    // Fallback: derive from cards if no header elements were found
     if (lanes.length === 0) {
       document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
         const lane = findCardLane(card);

--- a/content.js
+++ b/content.js
@@ -491,15 +491,17 @@
     }
 
     function removeExistingUpdateIndicator(timeElement) {
-      const existingIndicator = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator'
-      );
-      if (existingIndicator) existingIndicator.remove();
-
-      const existingSrText = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator-text'
-      );
-      if (existingSrText) existingSrText.remove();
+      const snTimeAgo = timeElement.closest('sn-time-ago');
+      const host = snTimeAgo ? snTimeAgo.parentElement : null;
+      if (!host) return;
+      Array.from(host.children).forEach((child) => {
+        if (
+          child.classList.contains('vtb-enhancer-update-indicator') ||
+          child.classList.contains('vtb-enhancer-update-indicator-text')
+        ) {
+          child.remove();
+        }
+      });
     }
 
     function getIndicatorEmojis() {
@@ -591,17 +593,19 @@
 
     function applyUpdateIndicator(timeElement) {
       const state = computeUpdateIndicatorState(timeElement);
-      const existingIndicator = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator'
+      const snTimeAgo = timeElement.closest('sn-time-ago');
+      const host = snTimeAgo ? snTimeAgo.parentElement : null;
+
+      const existingIndicator = host && Array.from(host.children).find(
+        (c) => c.classList.contains('vtb-enhancer-update-indicator')
       );
-      const existingSrText = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator-text'
+      const existingSrText = host && Array.from(host.children).find(
+        (c) => c.classList.contains('vtb-enhancer-update-indicator-text')
       );
 
       if (!state) {
-        if (existingIndicator || existingSrText) {
-          removeExistingUpdateIndicator(timeElement);
-        }
+        if (existingIndicator) existingIndicator.remove();
+        if (existingSrText) existingSrText.remove();
         return;
       }
 
@@ -614,50 +618,29 @@
         return;
       }
 
-      removeExistingUpdateIndicator(timeElement);
+      if (existingIndicator) existingIndicator.remove();
+      if (existingSrText) existingSrText.remove();
+
+      if (!snTimeAgo || !host) return;
 
       const indicatorSpan = document.createElement('span');
       indicatorSpan.className = 'vtb-enhancer-update-indicator';
       indicatorSpan.setAttribute('aria-hidden', 'true');
-      indicatorSpan.style.marginLeft = '4px';
       indicatorSpan.textContent = state.emoji;
 
       const srSpan = document.createElement('span');
       srSpan.className = 'sr-only vtb-enhancer-update-indicator-text';
       srSpan.textContent = state.srMessage;
 
-      const visibleSpan = Array.from(timeElement.children).find(
-        (child) =>
-          child.nodeType === Node.ELEMENT_NODE &&
-          child.tagName === 'SPAN' &&
-          !child.classList.contains('sr-only') &&
-          !child.classList.contains('vtb-enhancer-update-indicator') &&
-          !child.classList.contains('vtb-enhancer-update-indicator-text')
-      );
-
-      const srOnlyReference = Array.from(timeElement.children).find(
-        (child) =>
-          child.classList &&
-          child.classList.contains('sr-only') &&
-          !child.classList.contains('vtb-enhancer-update-indicator-text')
-      );
-
-      if (visibleSpan && typeof visibleSpan.after === 'function') {
-        visibleSpan.after(indicatorSpan);
-      } else if (srOnlyReference && srOnlyReference.parentNode) {
-        srOnlyReference.parentNode.insertBefore(
-          indicatorSpan,
-          srOnlyReference
-        );
-      } else {
-        timeElement.appendChild(indicatorSpan);
-      }
-
-      if (srOnlyReference && srOnlyReference.parentNode) {
-        srOnlyReference.parentNode.insertBefore(srSpan, srOnlyReference);
-      } else {
-        indicatorSpan.after(srSpan);
-      }
+      // Render after sn-time-ago (as a sibling), not inside the <time> element.
+      // sn-time-ago carries the class sn-card-component-time, which ServiceNow
+      // hides via opacity:0 (.state-hidden) on cards whose footer is collapsed
+      // until hover. Injecting inside that element makes the indicator inherit
+      // opacity:0 and stay invisible until the first hover. Placing it as a
+      // sibling keeps it outside that opacity scope while still in the same
+      // flex column, so it's always visible regardless of hover state.
+      snTimeAgo.after(indicatorSpan);
+      indicatorSpan.after(srSpan);
     }
 
     function detachTimeObserver(timeElement) {

--- a/content.js
+++ b/content.js
@@ -333,9 +333,11 @@
         if (!isNaN(parsedDate)) return parsedDate;
       }
 
-      const isoCandidate = trimmed.replace(' ', 'T');
-      const isoDate = new Date(isoCandidate);
-      if (!isNaN(isoDate)) return isoDate;
+      if (/^\d{4}[-T]/.test(trimmed)) {
+        const isoCandidate = trimmed.replace(' ', 'T');
+        const isoDate = new Date(isoCandidate);
+        if (!isNaN(isoDate)) return isoDate;
+      }
 
       const baseMatch = trimmed.match(
         /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/
@@ -884,10 +886,9 @@
       if (card.hasAttribute('data-task-age-enhanced')) return;
       try {
         annotateLastUpdated(card);
-        if (!config.enableAgeBadge) return;
         const state = findState(card);
-        if (state) {
-          if (isCompletionState(state)) {
+        if (state && isCompletionState(state)) {
+          if (config.enableAgeBadge) {
             const badge = createBadge('Done', '#28a745');
             if (getComputedStyle(card).position === 'static') {
               card.style.position = 'relative';
@@ -895,13 +896,15 @@
             card.appendChild(badge);
             card.setAttribute('data-task-age-enhanced', 'true');
             updatedCount++;
-            return;
           }
+          return;
         }
         const startDate = findStartDate(card);
         if (!startDate) return;
         const age = calculateDaysDiff(startDate);
         if (age === null) return;
+        card.setAttribute('data-task-age-days', age);
+        if (!config.enableAgeBadge) return;
         const badgeColor = getBadgeColor(age);
         const badge = createBadge(
           `Age: ${age} day${age !== 1 ? 's' : ''}`,
@@ -913,7 +916,6 @@
         }
         card.appendChild(badge);
         card.setAttribute('data-task-age-enhanced', 'true');
-        card.setAttribute('data-task-age-days', age);
         updatedCount++;
       } catch (err) {
         console.error('Work Item Age Error:', err);

--- a/content.js
+++ b/content.js
@@ -905,10 +905,6 @@
         if (age === null) return;
         card.setAttribute('data-task-age-days', age);
         if (!config.enableAgeBadge) return;
-        if (config.wipLanes && config.wipLanes.length > 0) {
-          const laneName = findCardLane(card);
-          if (laneName !== null && !config.wipLanes.includes(laneName)) return;
-        }
         const badgeColor = getBadgeColor(age);
         const badge = createBadge(
           `Age: ${age} day${age !== 1 ? 's' : ''}`,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"
@@ -14,7 +14,9 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.service-now.com/*vtb.do*"
+        "*://*.service-now.com/*vtb.do*",
+        "*://localhost/*vtb*",
+        "*://127.0.0.1/*vtb*"
       ],
       "js": [
         "content.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/options.html
+++ b/options.html
@@ -197,6 +197,26 @@
         color: #666;
         margin-top: 4px;
       }
+      .import-area {
+        margin-top: 12px;
+        display: none;
+      }
+      .import-area textarea {
+        width: 100%;
+        height: 160px;
+        box-sizing: border-box;
+        font-family: monospace;
+        font-size: 12px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 8px;
+        resize: vertical;
+      }
+      .import-area-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+      }
     </style>
   </head>
   <body>
@@ -329,6 +349,24 @@
         <button id="resetBtn" class="btn btn-secondary">
           Reset to Default
         </button>
+        <button id="exportBtn" class="btn btn-secondary" style="display:none;">
+          Export Settings
+        </button>
+        <button id="importBtn" class="btn btn-secondary" style="display:none;">
+          Import Settings
+        </button>
+      </div>
+      <div id="importArea" class="import-area">
+        <p class="field-help">
+          Paste the JSON from a previously exported board configuration, then
+          click <strong>Apply</strong>. Only board-level settings are imported;
+          your default configuration is not affected.
+        </p>
+        <textarea id="importTextarea" placeholder='{ "vtbEnhancerBoardConfig": { ... } }'></textarea>
+        <div class="import-area-actions">
+          <button id="applyImportBtn" class="btn">Apply</button>
+          <button id="cancelImportBtn" class="btn btn-secondary">Cancel</button>
+        </div>
       </div>
       <div id="status" style="margin-top: 20px"></div>
     </div>

--- a/options.html
+++ b/options.html
@@ -197,6 +197,23 @@
         color: #666;
         margin-top: 4px;
       }
+      .lane-checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 0;
+      }
+      .lane-checkbox-item input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .lane-checkbox-item label {
+        cursor: pointer;
+        font-weight: 400;
+        margin: 0;
+      }
     </style>
   </head>
   <body>
@@ -310,6 +327,16 @@
             Choose the emoji shown after the "time ago" text. Leave blank to
             fall back to the default icons.
           </p>
+        </div>
+        <div class="field-group" id="wipLanesSection" style="display:none;">
+          <label>WIP Lanes:</label>
+          <p class="field-help">
+            Check the lanes where the freshness indicator should appear. Leave
+            all unchecked to show on every card regardless of lane.
+          </p>
+          <div id="wipLanesList" style="margin-top: 8px;">
+            <!-- dynamically populated by options.js -->
+          </div>
         </div>
         <div class="preview-card" id="updatePreview">
           <div class="preview-text" style="width:100%;">

--- a/options.html
+++ b/options.html
@@ -484,6 +484,10 @@
           <h2>Service Level Expectations (SLE)</h2>
           <p>Set a day target per board. Age badges show an emoji and border when cards approach or breach the target.</p>
         </div>
+        <label class="switch">
+          <input type="checkbox" id="sleToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
 
       <div id="sleSection" class="feature-body">

--- a/options.html
+++ b/options.html
@@ -3,200 +3,281 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
-      rel="stylesheet"
-    />
     <style>
-      /* Modern UI styles */
+      *, *::before, *::after { box-sizing: border-box; }
+
       body {
-        font-family: "Roboto", sans-serif;
-        background-color: #f4f7f9;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background-color: #f0f4f8;
         margin: 0;
-        padding: 20px;
-        color: #333;
-      }
-      .container {
-        max-width: 600px;
-        margin: auto;
-        background: #fff;
-        padding: 30px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        border-radius: 8px;
-      }
-      h1 {
-        text-align: center;
-        margin-bottom: 20px;
-      }
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        margin-bottom: 20px;
-      }
-      th,
-      td {
-        padding: 12px;
-        text-align: left;
-        border-bottom: 1px solid #e0e0e0;
-        vertical-align: middle;
-      }
-      th {
-        background-color: #f1f3f5;
-      }
-      input[type="number"] {
-        width: 100%;
-        padding: 8px;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-      }
-      input[type="text"] {
-        width: 100%;
-        padding: 8px;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-      }
-      /* Style the color picker so the chosen color is clearly visible */
-      input[type="color"] {
-        width: 50px;
-        height: 50px;
-        padding: 0;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      .btn {
-        background-color: #007bff;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 4px;
-        cursor: pointer;
+        padding: 24px 16px 48px;
+        color: #1a202c;
         font-size: 14px;
-        margin-right: 10px;
+        line-height: 1.5;
       }
-      .btn:hover {
-        background-color: #0056b3;
+
+      .page-header {
+        max-width: 660px;
+        margin: 0 auto 24px;
+        text-align: center;
       }
-      .btn-secondary {
-        background-color: #6c757d;
+      .page-header h1 {
+        font-size: 20px;
+        font-weight: 700;
+        margin: 0 0 4px;
+        color: #1a202c;
       }
-      .btn-secondary:hover {
-        background-color: #565e64;
+      .page-header p {
+        font-size: 13px;
+        color: #718096;
+        margin: 0;
       }
-      .action-btn {
-        background-color: transparent;
-        border: none;
-        color: #d9534f;
+
+      /* Board selector */
+      .board-selector {
+        max-width: 660px;
+        margin: 0 auto 20px;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        padding: 16px 20px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .board-selector label {
+        font-weight: 600;
+        white-space: nowrap;
+        color: #2d3748;
+        font-size: 13px;
+      }
+      .board-selector select {
+        flex: 1;
+        padding: 7px 10px;
+        border: 1px solid #cbd5e0;
+        border-radius: 6px;
+        font-size: 13px;
+        color: #2d3748;
+        background: #f7fafc;
         cursor: pointer;
-        font-size: 16px;
       }
-      .field-group {
-        margin-bottom: 20px;
+      .board-selector .inherit-hint {
+        font-size: 11px;
+        color: #a0aec0;
+        white-space: nowrap;
       }
-      .field-group label {
-        display: block;
-        margin-bottom: 6px;
-        font-weight: 500;
+
+      /* Feature card */
+      .feature-card {
+        max-width: 660px;
+        margin: 0 auto 16px;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        overflow: hidden;
       }
-      .field-help {
+
+      .feature-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 20px;
+        border-bottom: 1px solid #e2e8f0;
+        background: #f7fafc;
+        gap: 12px;
+      }
+      .feature-header-text h2 {
+        font-size: 15px;
+        font-weight: 700;
+        margin: 0 0 2px;
+        color: #2d3748;
+      }
+      .feature-header-text p {
         font-size: 12px;
-        color: #666;
-        margin-top: 4px;
+        color: #718096;
+        margin: 0;
       }
+
+      /* Toggle switch */
       .switch {
         position: relative;
         display: inline-block;
-        width: 48px;
-        height: 26px;
+        width: 44px;
+        height: 24px;
+        flex-shrink: 0;
       }
-      .switch input {
-        opacity: 0;
-        width: 0;
-        height: 0;
-      }
+      .switch input { opacity: 0; width: 0; height: 0; }
       .slider {
         position: absolute;
         cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: #ccc;
+        inset: 0;
+        background-color: #cbd5e0;
         transition: 0.2s;
-        border-radius: 26px;
+        border-radius: 24px;
       }
       .slider:before {
         position: absolute;
         content: "";
-        height: 20px;
-        width: 20px;
+        height: 18px;
+        width: 18px;
         left: 3px;
         bottom: 3px;
         background-color: white;
         transition: 0.2s;
         border-radius: 50%;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        box-shadow: 0 1px 3px rgba(0,0,0,0.25);
       }
-      input:checked + .slider {
-        background-color: #007bff;
+      input:checked + .slider { background-color: #4299e1; }
+      input:checked + .slider:before { transform: translateX(20px); }
+
+      /* Feature body */
+      .feature-body {
+        padding: 20px;
       }
-      input:checked + .slider:before {
-        transform: translateX(22px);
+
+      .field-group {
+        margin-bottom: 20px;
       }
+      .field-group:last-child { margin-bottom: 0; }
+      .field-group > label {
+        display: block;
+        font-weight: 600;
+        font-size: 13px;
+        color: #2d3748;
+        margin-bottom: 6px;
+      }
+      .field-help {
+        font-size: 11px;
+        color: #718096;
+        margin-top: 5px;
+      }
+
+      input[type="number"],
+      input[type="text"] {
+        width: 100%;
+        padding: 7px 10px;
+        border: 1px solid #cbd5e0;
+        border-radius: 6px;
+        font-size: 13px;
+        color: #2d3748;
+        background: #f7fafc;
+      }
+      input[type="number"]:focus,
+      input[type="text"]:focus {
+        outline: none;
+        border-color: #4299e1;
+        background: #fff;
+      }
+
+      input[type="color"] {
+        width: 44px;
+        height: 44px;
+        padding: 2px;
+        border: 1px solid #cbd5e0;
+        border-radius: 6px;
+        cursor: pointer;
+        background: none;
+      }
+
+      /* Two-column emoji row */
+      .emoji-row {
+        display: flex;
+        gap: 16px;
+      }
+      .emoji-row > div {
+        flex: 1;
+      }
+      .emoji-row > div > label {
+        display: block;
+        font-size: 12px;
+        color: #4a5568;
+        margin-bottom: 4px;
+      }
+
+      /* Toggle inline row */
       .toggle-row {
         display: flex;
         align-items: center;
         gap: 10px;
-        flex-wrap: wrap;
       }
-      .section-title {
-        margin: 24px 0 8px;
-        font-size: 18px;
-        font-weight: 600;
-        color: #1f2933;
+      .toggle-row span {
+        font-size: 13px;
+        color: #2d3748;
       }
-      .preview-card {
-        margin-top: 12px;
-        padding: 16px;
-        border: 1px solid #e0e0e0;
-        border-radius: 8px;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        background: linear-gradient(135deg, #f8fafc, #eef2f7);
-      }
-      .preview-badge {
-        padding: 6px 10px;
-        border-radius: 6px;
-        font-weight: 700;
-        font-size: 12px;
-        min-width: 90px;
-        text-align: center;
-      }
-      .preview-text {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
+
+      /* Age bands table */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 12px;
         font-size: 13px;
       }
-      .actions-bar {
-        position: sticky;
-        bottom: 0;
-        background: #fff;
-        padding: 12px 0 0;
-        margin-top: 20px;
-        border-top: 1px solid #e0e0e0;
-        display: flex;
-        gap: 10px;
-        justify-content: flex-start;
+      th, td {
+        padding: 9px 10px;
+        text-align: left;
+        border-bottom: 1px solid #edf2f7;
+        vertical-align: middle;
       }
-      .inherit-hint {
+      th {
+        background: #f7fafc;
+        font-weight: 600;
         font-size: 12px;
-        color: #666;
-        margin-top: 4px;
+        color: #4a5568;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
       }
+      td input[type="number"] {
+        width: 100%;
+      }
+      .action-btn {
+        background: transparent;
+        border: none;
+        color: #fc8181;
+        cursor: pointer;
+        font-size: 15px;
+        padding: 2px 6px;
+        border-radius: 4px;
+        line-height: 1;
+      }
+      .action-btn:hover { background: #fff5f5; }
+
+      /* Preview card */
+      .preview-card {
+        background: linear-gradient(135deg, #f7fafc, #edf2f7);
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 14px 16px;
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+      }
+      .preview-badge {
+        padding: 5px 10px;
+        border-radius: 5px;
+        font-weight: 700;
+        font-size: 12px;
+        min-width: 48px;
+        text-align: center;
+        white-space: nowrap;
+      }
+      .preview-text {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 12px;
+        color: #4a5568;
+      }
+      .preview-text .preview-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+      }
+      .preview-text strong { color: #2d3748; }
+
+      /* WIP lane checkboxes */
       .lane-checkbox-item {
         display: flex;
         align-items: center;
@@ -204,193 +285,255 @@
         padding: 4px 0;
       }
       .lane-checkbox-item input[type="checkbox"] {
-        width: 16px;
-        height: 16px;
+        width: 15px;
+        height: 15px;
         cursor: pointer;
         flex-shrink: 0;
+        accent-color: #4299e1;
       }
       .lane-checkbox-item label {
         cursor: pointer;
-        font-weight: 400;
+        font-size: 13px;
+        color: #2d3748;
         margin: 0;
+      }
+
+      /* Hint block shown when default selected */
+      .hint-block {
+        padding: 12px 16px;
+        background: #ebf8ff;
+        border: 1px solid #bee3f8;
+        border-radius: 6px;
+        font-size: 12px;
+        color: #2b6cb0;
+      }
+
+      /* Buttons */
+      .btn {
+        background-color: #4299e1;
+        color: white;
+        border: none;
+        padding: 9px 20px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 13px;
+        font-weight: 600;
+        transition: background 0.15s;
+      }
+      .btn:hover { background-color: #3182ce; }
+      .btn-secondary {
+        background-color: #718096;
+      }
+      .btn-secondary:hover { background-color: #4a5568; }
+      .btn-sm {
+        padding: 6px 14px;
+        font-size: 12px;
+      }
+
+      /* Sticky actions bar */
+      .actions-bar {
+        position: sticky;
+        bottom: 0;
+        max-width: 660px;
+        margin: 20px auto 0;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        padding: 14px 20px;
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        box-shadow: 0 -2px 8px rgba(0,0,0,0.06);
+      }
+
+      #status {
+        font-size: 12px;
+        color: #38a169;
+        margin-left: auto;
+      }
+
+      /* Divider between sub-sections */
+      .section-divider {
+        border: none;
+        border-top: 1px solid #edf2f7;
+        margin: 20px 0;
       }
     </style>
   </head>
   <body>
-    <div class="container">
-      <h1>ServiceNow Visual Task Board Enhancer</h1>
-      <h1>Work Item Age Options</h1>
-      <p>
-        Use the switches below to turn the Work Item Age badge and the Last
-        Updated freshness indicator on or off. Changes apply to the default
-        configuration or the selected board; boards inherit defaults unless you
-        override them here.
-      </p>
-      <div class="field-group">
-        <label for="boardSelect">Board:</label>
-        <select id="boardSelect"></select>
-        <div class="inherit-hint">
-          Boards inherit defaults unless you override settings here. Blank
-          values fall back to defaults.
+    <div class="page-header">
+      <h1>ServiceNow VTB Enhancer</h1>
+      <p>Configure work item age badges, freshness indicators, and service level expectations per board.</p>
+    </div>
+
+    <!-- Board selector -->
+    <div class="board-selector">
+      <label for="boardSelect">Board:</label>
+      <select id="boardSelect"></select>
+      <span class="inherit-hint">Boards inherit defaults unless overridden.</span>
+    </div>
+
+    <!-- ── Feature 1: Work Item Age Badge ── -->
+    <div class="feature-card">
+      <div class="feature-header">
+        <div class="feature-header-text">
+          <h2>Work Item Age Badge</h2>
+          <p>Shows a color-coded age badge on every card based on the earliest of Actual start date, Start date, or Opened.</p>
         </div>
+        <label class="switch">
+          <input type="checkbox" id="ageBadgeToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
-      <div class="section-title">Work Item Age Badge</div>
-      <p class="field-help">
-        When enabled, each card shows a colored age badge based on its earliest
-        of Actual start date, Start date, or Opened. Completed states show a
-        green "Done" badge. Edit age bands to set the color thresholds; the
-        final band covers all older items.
-      </p>
-      <div class="field-group">
-        <div class="toggle-row">
-          <label class="switch">
-            <input type="checkbox" id="ageBadgeToggle" />
-            <span class="slider"></span>
-          </label>
+
+      <div id="ageBadgeSettings" class="feature-body">
+        <div class="field-group">
+          <label>Age bands</label>
+          <p class="field-help">
+            Each band covers ages up to its Max Days value. The last band (∞) catches everything older.
+            Completed cards always show a green "Done" badge regardless of age.
+          </p>
+          <table id="ageBandsTable">
+            <thead>
+              <tr>
+                <th>Max Days</th>
+                <th>Color</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <button id="addRowBtn" class="btn btn-sm btn-secondary">+ Add band</button>
         </div>
-        <p class="field-help">
-          Shows the colored age badge (including the "Done" badge) on cards.
-        </p>
-      </div>
-      <div id="ageBadgeSettings">
-        <table id="ageBandsTable">
-          <thead>
-            <tr>
-              <th>Max Days</th>
-              <th>Color</th>
-              <th>Remove</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Age band rows will be generated here -->
-          </tbody>
-        </table>
-        <button id="addRowBtn" class="btn">Add Age Band</button>
+
         <div class="preview-card" id="agePreview">
-          <div class="preview-badge" id="previewBadge">Age: 10 days</div>
+          <div class="preview-badge" id="previewBadge">10d</div>
           <div class="preview-text">
-            <span>Sample card badge using the first matching band color.</span>
+            <span>Preview of the age badge using the first matching band color for a 10-day-old card.</span>
           </div>
         </div>
       </div>
-      <div class="section-title">Last Updated Freshness Indicator</div>
-      <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card’s last
-        updated timestamp (bottom right corner of each VTB card). Set the
-        threshold in days to split fresh vs. stale, and pick emojis; leaving
-        them blank falls back to defaults.
-      </p>
-      <div class="field-group">
-        <div class="toggle-row">
-          <label class="switch">
-            <input type="checkbox" id="updateIndicatorToggle" />
-            <span class="slider"></span>
-          </label>
+    </div>
+
+    <!-- ── Feature 2: Last Updated Freshness Indicator ── -->
+    <div class="feature-card">
+      <div class="feature-header">
+        <div class="feature-header-text">
+          <h2>Last Updated Freshness Indicator</h2>
+          <p>Adds a fresh or stale emoji next to the "last updated" timestamp at the bottom right of each card.</p>
         </div>
-        <p class="field-help">
-          Adds the fresh/stale emoji beside the "last updated" timestamp.
-        </p>
+        <label class="switch">
+          <input type="checkbox" id="updateIndicatorToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
-      <div id="updateIndicatorSettings">
+
+      <div id="updateIndicatorSettings" class="feature-body">
         <div class="field-group">
-          <label for="thresholdInput">Update threshold (days):</label>
+          <label for="thresholdInput">Freshness threshold (days)</label>
           <input type="number" id="thresholdInput" min="0" step="0.1" />
-          <p class="field-help">
-            Cards updated within this many days display the "fresh" emoji. Older
-            cards show the "stale" emoji.
-          </p>
+          <p class="field-help">Cards updated within this many days show the "fresh" emoji; older cards show the "stale" emoji.</p>
         </div>
+
+        <hr class="section-divider" />
+
         <div class="field-group">
-          <label>Update status emoji:</label>
-          <div
-            style="
-              display: flex;
-              gap: 12px;
-              flex-wrap: wrap;
-              align-items: flex-start;
-            "
-          >
-            <div style="flex: 1; min-width: 120px">
-              <label for="freshEmojiInput" style="font-weight: 400"
-                >Fresh (within threshold)</label
-              >
-              <input type="text" id="freshEmojiInput" maxlength="8" />
+          <label>Status emoji</label>
+          <div class="emoji-row">
+            <div>
+              <label for="freshEmojiInput">Fresh (within threshold)</label>
+              <input type="text" id="freshEmojiInput" maxlength="8" placeholder="✅" />
             </div>
-            <div style="flex: 1; min-width: 120px">
-              <label for="staleEmojiInput" style="font-weight: 400"
-                >Stale (over threshold)</label
-              >
-              <input type="text" id="staleEmojiInput" maxlength="8" />
+            <div>
+              <label for="staleEmojiInput">Stale (over threshold)</label>
+              <input type="text" id="staleEmojiInput" maxlength="8" placeholder="❌" />
             </div>
           </div>
-          <p class="field-help">
-            Choose the emoji shown after the "time ago" text. Leave blank to
-            fall back to the default icons.
-          </p>
+          <p class="field-help">Leave blank to use the defaults (✅ / ❌).</p>
         </div>
+
+        <hr class="section-divider" />
+
         <div class="field-group" id="wipLanesSection" style="display:none;">
-          <label>WIP Lanes:</label>
+          <label>WIP lanes</label>
           <p class="field-help">
-            Check the lanes where the freshness indicator should appear. Leave
-            all unchecked to show on every card regardless of lane.
+            Check the lanes where the freshness indicator should appear. Leave all unchecked to show it on every card regardless of lane.
           </p>
-          <div id="wipLanesList" style="margin-top: 8px;">
-            <!-- dynamically populated by options.js -->
-          </div>
+          <div id="wipLanesList" style="margin-top: 8px;"></div>
         </div>
+
         <div class="preview-card" id="updatePreview">
           <div class="preview-text" style="width:100%;">
-            <div style="display:flex; gap:12px; align-items:center; justify-content:space-between;">
+            <div class="preview-row">
               <strong>Fresh example</strong>
-              <span id="previewFresh" style="font-weight:600;">2d ago ?</span>
+              <span id="previewFresh" style="font-weight:600;">2d ago ✅</span>
             </div>
-            <div style="display:flex; gap:12px; align-items:center; justify-content:space-between;">
+            <div class="preview-row">
               <strong>Stale example</strong>
-              <span id="previewStale" style="font-weight:600;">4d ago ?</span>
+              <span id="previewStale" style="font-weight:600;">4d ago ❌</span>
             </div>
           </div>
         </div>
       </div>
-      <div class="section-title">Service Level Expectations</div>
-      <p class="field-help">
-        Set an SLE target (in days) for this board. When set, age badges show a
-        colored border as cards approach or exceed the target, and a summary
-        counter appears near the board title. SLE is configured per board —
-        select a board above to set its target.
-      </p>
-      <div id="sleSection">
-        <p class="field-help" id="sleDefaultHint" style="display:none;">
-          Select a specific board from the dropdown above to configure its SLE.
-        </p>
+    </div>
+
+    <!-- ── Feature 3: Service Level Expectations ── -->
+    <div class="feature-card">
+      <div class="feature-header">
+        <div class="feature-header-text">
+          <h2>Service Level Expectations (SLE)</h2>
+          <p>Set a day target per board. Age badges show an emoji and border when cards approach or breach the target.</p>
+        </div>
+      </div>
+
+      <div id="sleSection" class="feature-body">
+        <div class="hint-block" id="sleDefaultHint" style="display:none;">
+          SLE is configured per board — select a specific board from the dropdown above.
+        </div>
+
         <div id="sleFields">
           <div class="field-group">
-            <label for="sleDaysInput">SLE target (days, 0 = disabled):</label>
+            <label for="sleDaysInput">SLE target (days, 0 = disabled)</label>
             <input type="number" id="sleDaysInput" min="0" step="1" value="0" />
-            <p class="field-help">
-              Cards older than this many days are considered over SLE.
-            </p>
+            <p class="field-help">Cards older than this many days are considered over SLE.</p>
           </div>
+
           <div class="field-group">
-            <label for="sleApproachingInput">Approaching warning (days before SLE):</label>
+            <label for="sleApproachingInput">Approaching warning (days before target)</label>
             <input type="number" id="sleApproachingInput" min="0" step="1" value="3" />
-            <p class="field-help">
-              Show an approaching warning when a card is within this many days of
-              the SLE target.
-            </p>
+            <p class="field-help">Show an approaching warning when a card is within this many days of the SLE target.</p>
           </div>
+
+          <hr class="section-divider" />
+
+          <div class="field-group">
+            <label>SLE status emoji</label>
+            <div class="emoji-row">
+              <div>
+                <label for="sleApproachingEmojiInput">Approaching target</label>
+                <input type="text" id="sleApproachingEmojiInput" maxlength="8" placeholder="⚠️" />
+              </div>
+              <div>
+                <label for="sleBreachedEmojiInput">Breached target</label>
+                <input type="text" id="sleBreachedEmojiInput" maxlength="8" placeholder="🔴" />
+              </div>
+            </div>
+            <p class="field-help">These emojis are prepended to the age badge when escalation is enabled. Leave blank to use defaults (⚠️ / 🔴).</p>
+          </div>
+
+          <hr class="section-divider" />
+
           <div class="field-group">
             <div class="toggle-row">
               <label class="switch">
                 <input type="checkbox" id="sleSummaryToggle" checked />
                 <span class="slider"></span>
               </label>
-              <span>Show board summary bar</span>
+              <span>Show summary bar near board title</span>
             </div>
-            <p class="field-help">
-              Display over/approaching counts near the board title when the VTB
-              is open.
-            </p>
+            <p class="field-help">Displays over/approaching counts inline next to the board name when the VTB is open.</p>
           </div>
+
           <div class="field-group">
             <div class="toggle-row">
               <label class="switch">
@@ -399,29 +542,23 @@
               </label>
               <span>Escalate age badge appearance near SLE</span>
             </div>
-            <p class="field-help">
-              Add a dashed orange border (approaching) or solid red border (over)
-              to the age badge as items near the SLE target.
-            </p>
+            <p class="field-help">Adds an emoji prefix and colored border to the age badge as cards approach (dashed orange) or breach (solid red) the target.</p>
           </div>
         </div>
       </div>
-      <div class="actions-bar">
-        <button id="saveBtn" class="btn">Save</button>
-        <button id="resetBtn" class="btn btn-secondary">
-          Reset to Default
-        </button>
-        <button id="exportBtn" class="btn btn-secondary" style="display:none;">
-          Export Settings
-        </button>
-        <button id="importBtn" class="btn btn-secondary" style="display:none;">
-          Import Settings
-        </button>
-      </div>
-      <input type="file" id="importFileInput" accept=".json" style="display:none;" />
-      <div id="status" style="margin-top: 20px"></div>
     </div>
+
+    <!-- ── Actions bar ── -->
+    <div class="actions-bar">
+      <button id="saveBtn" class="btn">Save</button>
+      <button id="resetBtn" class="btn btn-secondary">Reset to Default</button>
+      <button id="exportBtn" class="btn btn-secondary" style="display:none;">Export</button>
+      <button id="importBtn" class="btn btn-secondary" style="display:none;">Import</button>
+      <span id="status"></span>
+    </div>
+
+    <input type="file" id="importFileInput" accept=".json" style="display:none;" />
+
     <script src="options.js"></script>
   </body>
 </html>
-

--- a/options.html
+++ b/options.html
@@ -214,26 +214,6 @@
         font-weight: 400;
         margin: 0;
       }
-      .import-area {
-        margin-top: 12px;
-        display: none;
-      }
-      .import-area textarea {
-        width: 100%;
-        height: 160px;
-        box-sizing: border-box;
-        font-family: monospace;
-        font-size: 12px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        padding: 8px;
-        resize: vertical;
-      }
-      .import-area-actions {
-        display: flex;
-        gap: 8px;
-        margin-top: 8px;
-      }
     </style>
   </head>
   <body>
@@ -438,18 +418,7 @@
           Import Settings
         </button>
       </div>
-      <div id="importArea" class="import-area">
-        <p class="field-help">
-          Paste the JSON from a previously exported board configuration, then
-          click <strong>Apply</strong>. Only board-level settings are imported;
-          your default configuration is not affected.
-        </p>
-        <textarea id="importTextarea" placeholder='{ "vtbEnhancerBoardConfig": { ... } }'></textarea>
-        <div class="import-area-actions">
-          <button id="applyImportBtn" class="btn">Apply</button>
-          <button id="cancelImportBtn" class="btn btn-secondary">Cancel</button>
-        </div>
-      </div>
+      <input type="file" id="importFileInput" accept=".json" style="display:none;" />
       <div id="status" style="margin-top: 20px"></div>
     </div>
     <script src="options.js"></script>

--- a/options.html
+++ b/options.html
@@ -324,6 +324,61 @@
           </div>
         </div>
       </div>
+      <div class="section-title">Service Level Expectations</div>
+      <p class="field-help">
+        Set an SLE target (in days) for this board. When set, age badges show a
+        colored border as cards approach or exceed the target, and a summary
+        counter appears near the board title. SLE is configured per board —
+        select a board above to set its target.
+      </p>
+      <div id="sleSection">
+        <p class="field-help" id="sleDefaultHint" style="display:none;">
+          Select a specific board from the dropdown above to configure its SLE.
+        </p>
+        <div id="sleFields">
+          <div class="field-group">
+            <label for="sleDaysInput">SLE target (days, 0 = disabled):</label>
+            <input type="number" id="sleDaysInput" min="0" step="1" value="0" />
+            <p class="field-help">
+              Cards older than this many days are considered over SLE.
+            </p>
+          </div>
+          <div class="field-group">
+            <label for="sleApproachingInput">Approaching warning (days before SLE):</label>
+            <input type="number" id="sleApproachingInput" min="0" step="1" value="3" />
+            <p class="field-help">
+              Show an approaching warning when a card is within this many days of
+              the SLE target.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleSummaryToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Show board summary bar</span>
+            </div>
+            <p class="field-help">
+              Display over/approaching counts near the board title when the VTB
+              is open.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleEscalationToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Escalate age badge appearance near SLE</span>
+            </div>
+            <p class="field-help">
+              Add a dashed orange border (approaching) or solid red border (over)
+              to the age badge as items near the SLE target.
+            </p>
+          </div>
+        </div>
+      </div>
       <div class="actions-bar">
         <button id="saveBtn" class="btn">Save</button>
         <button id="resetBtn" class="btn btn-secondary">

--- a/options.js
+++ b/options.js
@@ -47,10 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const wipLanesList = document.getElementById('wipLanesList');
   const exportBtn = document.getElementById('exportBtn');
   const importBtn = document.getElementById('importBtn');
-  const importArea = document.getElementById('importArea');
-  const importTextarea = document.getElementById('importTextarea');
-  const applyImportBtn = document.getElementById('applyImportBtn');
-  const cancelImportBtn = document.getElementById('cancelImportBtn');
+  const importFileInput = document.getElementById('importFileInput');
   const sleDaysInput = document.getElementById('sleDaysInput');
   const sleApproachingInput = document.getElementById('sleApproachingInput');
   const sleSummaryToggle = document.getElementById('sleSummaryToggle');
@@ -500,10 +497,6 @@ document.addEventListener('DOMContentLoaded', function () {
     const show = !!currentBoardId;
     exportBtn.style.display = show ? '' : 'none';
     importBtn.style.display = show ? '' : 'none';
-    if (!show) {
-      importArea.style.display = 'none';
-      importTextarea.value = '';
-    }
   }
 
   function exportBoardConfig() {
@@ -592,27 +585,26 @@ document.addEventListener('DOMContentLoaded', function () {
   exportBtn.addEventListener('click', exportBoardConfig);
 
   importBtn.addEventListener('click', () => {
-    importArea.style.display = importArea.style.display === 'none' ? '' : 'none';
-    importTextarea.value = '';
+    importFileInput.value = '';
+    importFileInput.click();
   });
 
-  cancelImportBtn.addEventListener('click', () => {
-    importArea.style.display = 'none';
-    importTextarea.value = '';
-  });
-
-  applyImportBtn.addEventListener('click', () => {
-    const err = applyImportedConfig(importTextarea.value.trim());
-    if (err) {
-      statusDiv.textContent = err;
-    } else {
-      importArea.style.display = 'none';
-      importTextarea.value = '';
-      saveConfig(fullConfig, () => {
-        statusDiv.textContent = 'Settings imported and saved.';
-        setTimeout(() => { statusDiv.textContent = ''; }, 3000);
-      });
-    }
+  importFileInput.addEventListener('change', () => {
+    const file = importFileInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const err = applyImportedConfig(e.target.result);
+      if (err) {
+        statusDiv.textContent = err;
+      } else {
+        saveConfig(fullConfig, () => {
+          statusDiv.textContent = 'Settings imported and saved.';
+          setTimeout(() => { statusDiv.textContent = ''; }, 3000);
+        });
+      }
+    };
+    reader.readAsText(file);
   });
 
   // --- End Export / Import ---

--- a/options.js
+++ b/options.js
@@ -52,6 +52,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const sleApproachingInput = document.getElementById('sleApproachingInput');
   const sleSummaryToggle = document.getElementById('sleSummaryToggle');
   const sleEscalationToggle = document.getElementById('sleEscalationToggle');
+  const sleApproachingEmojiInput = document.getElementById('sleApproachingEmojiInput');
+  const sleBreachedEmojiInput = document.getElementById('sleBreachedEmojiInput');
   const sleDefaultHint = document.getElementById('sleDefaultHint');
   const sleFields = document.getElementById('sleFields');
 
@@ -166,12 +168,14 @@ document.addEventListener('DOMContentLoaded', function () {
           : cfg.defaultConfig.enableUpdateIndicator;
 
       if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
       } else {
         if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
         if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
         if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
         if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+        if (!boardCfg.sle.approachingEmoji || typeof boardCfg.sle.approachingEmoji !== 'string') boardCfg.sle.approachingEmoji = '⚠️';
+        if (!boardCfg.sle.breachedEmoji || typeof boardCfg.sle.breachedEmoji !== 'string') boardCfg.sle.breachedEmoji = '🔴';
       }
     });
 
@@ -249,11 +253,13 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function renderSleToUI(sle) {
-    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
     sleDaysInput.value = s.days;
     sleApproachingInput.value = s.approachingDays;
     sleSummaryToggle.checked = s.showSummary !== false;
     sleEscalationToggle.checked = s.showBadgeEscalation !== false;
+    sleApproachingEmojiInput.value = s.approachingEmoji || '⚠️';
+    sleBreachedEmojiInput.value = s.breachedEmoji || '🔴';
   }
 
   function getSleFromInputs() {
@@ -264,6 +270,8 @@ document.addEventListener('DOMContentLoaded', function () {
       approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
       showSummary: sleSummaryToggle.checked,
       showBadgeEscalation: sleEscalationToggle.checked,
+      approachingEmoji: sleApproachingEmojiInput.value.trim() || '⚠️',
+      breachedEmoji: sleBreachedEmojiInput.value.trim() || '🔴',
     };
   }
 
@@ -299,7 +307,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const color = getPreviewBandColor();
       previewBadge.style.backgroundColor = color;
       previewBadge.style.color = '#fff';
-      previewBadge.textContent = 'Age: 10 days';
+      previewBadge.textContent = '10d';
       previewBadge.style.display = '';
     } else if (previewBadge) {
       previewBadge.style.display = 'none';
@@ -518,7 +526,7 @@ document.addEventListener('DOMContentLoaded', function () {
         wipLanes: Array.isArray(board.wipLanes) ? [...board.wipLanes] : [],
         sle: board.sle && typeof board.sle === 'object'
           ? { ...board.sle }
-          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
+          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
       },
     };
     const json = JSON.stringify(payload, null, 2);
@@ -575,6 +583,8 @@ document.addEventListener('DOMContentLoaded', function () {
         approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
         showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
         showBadgeEscalation: typeof incoming.sle.showBadgeEscalation === 'boolean' ? incoming.sle.showBadgeEscalation : true,
+        approachingEmoji: typeof incoming.sle.approachingEmoji === 'string' && incoming.sle.approachingEmoji.trim() ? incoming.sle.approachingEmoji : '⚠️',
+        breachedEmoji: typeof incoming.sle.breachedEmoji === 'string' && incoming.sle.breachedEmoji.trim() ? incoming.sle.breachedEmoji : '🔴',
       };
     }
 

--- a/options.js
+++ b/options.js
@@ -522,6 +522,10 @@ document.addEventListener('DOMContentLoaded', function () {
           ? board.updateThresholdDays
           : fullConfig.defaultConfig.updateThresholdDays,
         updateIndicator: { ...normalizeIndicator(board.updateIndicator, fullConfig.defaultConfig.updateIndicator) },
+        wipLanes: Array.isArray(board.wipLanes) ? [...board.wipLanes] : [],
+        sle: board.sle && typeof board.sle === 'object'
+          ? { ...board.sle }
+          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
       },
     };
     const json = JSON.stringify(payload, null, 2);
@@ -568,6 +572,17 @@ document.addEventListener('DOMContentLoaded', function () {
         (b) => b && typeof b.maxDays === 'number' && b.maxDays > 0 && typeof b.color === 'string'
       );
       if (bands.length > 0) target.ageBands = bands;
+    }
+    if (Array.isArray(incoming.wipLanes)) {
+      target.wipLanes = incoming.wipLanes.filter((l) => typeof l === 'string');
+    }
+    if (incoming.sle && typeof incoming.sle === 'object') {
+      target.sle = {
+        days: typeof incoming.sle.days === 'number' && incoming.sle.days >= 0 ? incoming.sle.days : 0,
+        approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
+        showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
+        showBadgeEscalation: typeof incoming.sle.showBadgeEscalation === 'boolean' ? incoming.sle.showBadgeEscalation : true,
+      };
     }
 
     renderConfigToUI(getCurrentConfig());

--- a/options.js
+++ b/options.js
@@ -43,6 +43,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const sleDaysInput = document.getElementById('sleDaysInput');
+  const sleApproachingInput = document.getElementById('sleApproachingInput');
+  const sleSummaryToggle = document.getElementById('sleSummaryToggle');
+  const sleEscalationToggle = document.getElementById('sleEscalationToggle');
+  const sleDefaultHint = document.getElementById('sleDefaultHint');
+  const sleFields = document.getElementById('sleFields');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
@@ -153,6 +159,15 @@ document.addEventListener('DOMContentLoaded', function () {
         typeof boardCfg.enableUpdateIndicator === 'boolean'
           ? boardCfg.enableUpdateIndicator
           : cfg.defaultConfig.enableUpdateIndicator;
+
+      if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+      } else {
+        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+        if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+        if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+        if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+      }
     });
 
     return cfg;
@@ -172,6 +187,35 @@ document.addEventListener('DOMContentLoaded', function () {
         ? source.staleEmoji
         : base.staleEmoji;
     return { freshEmoji: fresh, staleEmoji: stale };
+  }
+
+  function updateSleVisibility() {
+    if (currentBoardId) {
+      sleDefaultHint.style.display = 'none';
+      sleFields.style.display = '';
+    } else {
+      sleDefaultHint.style.display = '';
+      sleFields.style.display = 'none';
+    }
+  }
+
+  function renderSleToUI(sle) {
+    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+    sleDaysInput.value = s.days;
+    sleApproachingInput.value = s.approachingDays;
+    sleSummaryToggle.checked = s.showSummary !== false;
+    sleEscalationToggle.checked = s.showBadgeEscalation !== false;
+  }
+
+  function getSleFromInputs() {
+    const days = parseInt(sleDaysInput.value, 10);
+    const approachingDays = parseInt(sleApproachingInput.value, 10);
+    return {
+      days: isNaN(days) || days < 0 ? 0 : days,
+      approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
+      showSummary: sleSummaryToggle.checked,
+      showBadgeEscalation: sleEscalationToggle.checked,
+    };
   }
 
   function toggleSettingsVisibility() {
@@ -249,6 +293,12 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateSleVisibility();
+    if (currentBoardId) {
+      const boardSle = fullConfig.boards[currentBoardId] && fullConfig.boards[currentBoardId].sle;
+      renderSleToUI(boardSle);
+    }
   }
 
   function refreshTable() {
@@ -392,6 +442,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateSleVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 
@@ -432,6 +483,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].sle = getSleFromInputs();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -455,6 +507,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].sle;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();

--- a/options.js
+++ b/options.js
@@ -43,6 +43,12 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const exportBtn = document.getElementById('exportBtn');
+  const importBtn = document.getElementById('importBtn');
+  const importArea = document.getElementById('importArea');
+  const importTextarea = document.getElementById('importTextarea');
+  const applyImportBtn = document.getElementById('applyImportBtn');
+  const cancelImportBtn = document.getElementById('cancelImportBtn');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
@@ -249,6 +255,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateExportImportVisibility();
   }
 
   function refreshTable() {
@@ -390,8 +398,117 @@ document.addEventListener('DOMContentLoaded', function () {
     };
   }
 
+  // --- Export / Import ---
+
+  function updateExportImportVisibility() {
+    const show = !!currentBoardId;
+    exportBtn.style.display = show ? '' : 'none';
+    importBtn.style.display = show ? '' : 'none';
+    if (!show) {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+    }
+  }
+
+  function exportBoardConfig() {
+    if (!currentBoardId) return;
+    const board = fullConfig.boards[currentBoardId] || {};
+    const payload = {
+      vtbEnhancerBoardConfig: {
+        enableAgeBadge: typeof board.enableAgeBadge === 'boolean'
+          ? board.enableAgeBadge
+          : fullConfig.defaultConfig.enableAgeBadge,
+        enableUpdateIndicator: typeof board.enableUpdateIndicator === 'boolean'
+          ? board.enableUpdateIndicator
+          : fullConfig.defaultConfig.enableUpdateIndicator,
+        ageBands: (board.ageBands || fullConfig.defaultConfig.ageBands).map((b) => ({ ...b })),
+        updateThresholdDays: typeof board.updateThresholdDays === 'number'
+          ? board.updateThresholdDays
+          : fullConfig.defaultConfig.updateThresholdDays,
+        updateIndicator: { ...normalizeIndicator(board.updateIndicator, fullConfig.defaultConfig.updateIndicator) },
+      },
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const boardName = (board.name || currentBoardId).replace(/[^a-z0-9]/gi, '-').toLowerCase();
+    a.href = url;
+    a.download = `vtb-board-config-${boardName}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function applyImportedConfig(jsonStr) {
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (_) {
+      return 'Invalid JSON — please check the pasted text and try again.';
+    }
+    const incoming = parsed && parsed.vtbEnhancerBoardConfig;
+    if (!incoming || typeof incoming !== 'object') {
+      return 'Unrecognised format — the JSON must contain a "vtbEnhancerBoardConfig" key.';
+    }
+    if (!currentBoardId) return 'No board selected.';
+
+    if (!fullConfig.boards[currentBoardId]) {
+      fullConfig.boards[currentBoardId] = { name: currentBoardId };
+    }
+    const target = fullConfig.boards[currentBoardId];
+
+    if (typeof incoming.enableAgeBadge === 'boolean') target.enableAgeBadge = incoming.enableAgeBadge;
+    if (typeof incoming.enableUpdateIndicator === 'boolean') target.enableUpdateIndicator = incoming.enableUpdateIndicator;
+    if (typeof incoming.updateThresholdDays === 'number' && incoming.updateThresholdDays >= 0) {
+      target.updateThresholdDays = incoming.updateThresholdDays;
+    }
+    if (incoming.updateIndicator && typeof incoming.updateIndicator === 'object') {
+      target.updateIndicator = normalizeIndicator(incoming.updateIndicator, fullConfig.defaultConfig.updateIndicator);
+    }
+    if (Array.isArray(incoming.ageBands) && incoming.ageBands.length > 0) {
+      const bands = incoming.ageBands.filter(
+        (b) => b && typeof b.maxDays === 'number' && b.maxDays > 0 && typeof b.color === 'string'
+      );
+      if (bands.length > 0) target.ageBands = bands;
+    }
+
+    renderConfigToUI(getCurrentConfig());
+    return null; // no error
+  }
+
+  exportBtn.addEventListener('click', exportBoardConfig);
+
+  importBtn.addEventListener('click', () => {
+    importArea.style.display = importArea.style.display === 'none' ? '' : 'none';
+    importTextarea.value = '';
+  });
+
+  cancelImportBtn.addEventListener('click', () => {
+    importArea.style.display = 'none';
+    importTextarea.value = '';
+  });
+
+  applyImportBtn.addEventListener('click', () => {
+    const err = applyImportedConfig(importTextarea.value.trim());
+    if (err) {
+      statusDiv.textContent = err;
+    } else {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+      saveConfig(fullConfig, () => {
+        statusDiv.textContent = 'Settings imported and saved.';
+        setTimeout(() => { statusDiv.textContent = ''; }, 3000);
+      });
+    }
+  });
+
+  // --- End Export / Import ---
+
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateExportImportVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 

--- a/options.js
+++ b/options.js
@@ -54,6 +54,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const sleEscalationToggle = document.getElementById('sleEscalationToggle');
   const sleApproachingEmojiInput = document.getElementById('sleApproachingEmojiInput');
   const sleBreachedEmojiInput = document.getElementById('sleBreachedEmojiInput');
+  const sleToggle = document.getElementById('sleToggle');
   const sleDefaultHint = document.getElementById('sleDefaultHint');
   const sleFields = document.getElementById('sleFields');
 
@@ -168,8 +169,9 @@ document.addEventListener('DOMContentLoaded', function () {
           : cfg.defaultConfig.enableUpdateIndicator;
 
       if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+        boardCfg.sle = { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
       } else {
+        if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = true;
         if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
         if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
         if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
@@ -245,7 +247,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function updateSleVisibility() {
     if (currentBoardId) {
       sleDefaultHint.style.display = 'none';
-      sleFields.style.display = '';
+      sleFields.style.display = sleToggle.checked ? '' : 'none';
     } else {
       sleDefaultHint.style.display = '';
       sleFields.style.display = 'none';
@@ -253,7 +255,8 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function renderSleToUI(sle) {
-    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+    const s = sle || { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+    sleToggle.checked = s.enabled !== false;
     sleDaysInput.value = s.days;
     sleApproachingInput.value = s.approachingDays;
     sleSummaryToggle.checked = s.showSummary !== false;
@@ -266,6 +269,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const days = parseInt(sleDaysInput.value, 10);
     const approachingDays = parseInt(sleApproachingInput.value, 10);
     return {
+      enabled: sleToggle.checked,
       days: isNaN(days) || days < 0 ? 0 : days,
       approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
       showSummary: sleSummaryToggle.checked,
@@ -353,11 +357,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     renderWipLanes(currentBoardId);
     updateExportImportVisibility();
-    updateSleVisibility();
+    // Render SLE fields first so that sleToggle.checked is set before updateSleVisibility reads it.
     if (currentBoardId) {
       const boardSle = fullConfig.boards[currentBoardId] && fullConfig.boards[currentBoardId].sle;
       renderSleToUI(boardSle);
+    } else {
+      sleToggle.checked = true;
     }
+    updateSleVisibility();
   }
 
   function refreshTable() {
@@ -526,7 +533,7 @@ document.addEventListener('DOMContentLoaded', function () {
         wipLanes: Array.isArray(board.wipLanes) ? [...board.wipLanes] : [],
         sle: board.sle && typeof board.sle === 'object'
           ? { ...board.sle }
-          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
+          : { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
       },
     };
     const json = JSON.stringify(payload, null, 2);
@@ -579,6 +586,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     if (incoming.sle && typeof incoming.sle === 'object') {
       target.sle = {
+        enabled: typeof incoming.sle.enabled === 'boolean' ? incoming.sle.enabled : true,
         days: typeof incoming.sle.days === 'number' && incoming.sle.days >= 0 ? incoming.sle.days : 0,
         approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
         showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
@@ -628,6 +636,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   ageBadgeToggle.addEventListener('change', toggleSettingsVisibility);
   updateIndicatorToggle.addEventListener('change', toggleSettingsVisibility);
+  sleToggle.addEventListener('change', updateSleVisibility);
   thresholdInput.addEventListener('input', updatePreview);
   freshEmojiInput.addEventListener('input', updatePreview);
   staleEmojiInput.addEventListener('input', updatePreview);

--- a/options.js
+++ b/options.js
@@ -43,6 +43,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const wipLanesSection = document.getElementById('wipLanesSection');
+  const wipLanesList = document.getElementById('wipLanesList');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
@@ -174,6 +176,50 @@ document.addEventListener('DOMContentLoaded', function () {
     return { freshEmoji: fresh, staleEmoji: stale };
   }
 
+  function renderWipLanes(boardId) {
+    if (!boardId) {
+      wipLanesSection.style.display = 'none';
+      return;
+    }
+    const boardCfg = fullConfig.boards[boardId];
+    const lanes = (boardCfg && Array.isArray(boardCfg.lanes)) ? boardCfg.lanes : [];
+    const wipLanes = (boardCfg && Array.isArray(boardCfg.wipLanes)) ? boardCfg.wipLanes : [];
+
+    wipLanesList.innerHTML = '';
+    if (lanes.length === 0) {
+      const hint = document.createElement('p');
+      hint.className = 'field-help';
+      hint.textContent = 'No lanes discovered yet. Visit this board in ServiceNow, then return here to configure WIP lanes.';
+      wipLanesList.appendChild(hint);
+    } else {
+      lanes.forEach((lane) => {
+        const item = document.createElement('div');
+        item.className = 'lane-checkbox-item';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        const safeId = 'lane-' + lane.replace(/[^a-z0-9]/gi, '-');
+        cb.id = safeId;
+        cb.value = lane;
+        cb.checked = wipLanes.includes(lane);
+        const lbl = document.createElement('label');
+        lbl.htmlFor = safeId;
+        lbl.textContent = lane;
+        item.appendChild(cb);
+        item.appendChild(lbl);
+        wipLanesList.appendChild(item);
+      });
+    }
+    wipLanesSection.style.display = '';
+  }
+
+  function getWipLanesFromUI() {
+    const checked = [];
+    wipLanesList.querySelectorAll('input[type="checkbox"]:checked').forEach((cb) => {
+      checked.push(cb.value);
+    });
+    return checked;
+  }
+
   function toggleSettingsVisibility() {
     const showAge = ageBadgeToggle.checked;
     const showUpdate = updateIndicatorToggle.checked;
@@ -249,6 +295,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    renderWipLanes(currentBoardId);
   }
 
   function refreshTable() {
@@ -432,6 +480,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].wipLanes = getWipLanesFromUI();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -455,6 +504,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].wipLanes;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -163,7 +163,7 @@
   }
 
   // CSS selectors tried in order when searching for a lane/column title element.
-  // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+  // ServiceNow VTB renders lanes as columns; the title is in a header child element.
   const LANE_TITLE_SELECTORS = [
     '.vtb-lane-header-title',
     '.sn-board-header-title',
@@ -172,15 +172,44 @@
     '[class*="lane"] > [class*="header"] > [class*="title"]',
   ];
 
-  // Strips trailing card-count badges from lane header text so stored names and
-  // runtime names stay in sync even when card counts change (e.g. "In Progress (5)" → "In Progress").
-  function normalizeLaneName(text) {
-    // Prefer text from direct text nodes only (avoids child badge elements entirely).
-    // Falls back to stripping the common "(N)" suffix pattern.
-    return text.replace(/\s*\(\d+\)\s*$/, '').trim();
+  // Extracts the lane name text from a lane-title container element.
+  //
+  // ServiceNow VTB uses an AngularJS form pattern inside .vtb-lane-header-title:
+  //   <div class="vtb-lane-header-title">
+  //     <form data-original-title="In Flight" class="vtb-lane-title ...">
+  //       <label class="ng-binding ...">In Flight</label>
+  //       <input value="In Flight">
+  //     </form>
+  //   </div>
+  //
+  // The card count lives in a separate sibling div (.vtb-lane-header-count) and
+  // never appears inside the title element itself.
+  //
+  // However, AngularJS directives such as sn-tooltip-basic and sn-focus-input can
+  // inject hidden helper spans/elements inside the form, which pollute textContent.
+  // To get a clean, stable lane name we prefer these sources in order:
+  //   1. The inner <label> textContent — AngularJS keeps this bound exactly to the
+  //      lane name (ng-binding) with no extra injected text.
+  //   2. data-original-title on the <form> — set by sn-tooltip-basic to the lane name.
+  //   3. Normalized full textContent of the container as a last resort.
+  function getLaneTitleText(el) {
+    const label = el.querySelector('label');
+    if (label) {
+      const t = label.textContent.trim();
+      if (t) return t;
+    }
+    const formEl = el.matches && el.matches('form') ? el : el.querySelector('form');
+    if (formEl) {
+      const attr = formEl.getAttribute('data-original-title');
+      if (attr && attr.trim()) return attr.trim();
+    }
+    // Strip trailing "(N)" count patterns as a fallback safety measure
+    return el.textContent.trim().replace(/\s*\(\d+\)\s*$/, '').trim();
   }
 
   // Returns the lane (column) name for a given card by walking up the DOM.
+  // If the walk-up finds no header (e.g. lane headers and card lists are in
+  // parallel DOM branches), falls back to positional matching.
   function findCardLane(card) {
     let el = card.parentElement;
     while (el && el !== document.body) {
@@ -188,14 +217,42 @@
         try {
           const found = el.querySelector(sel);
           if (found) {
-            const text = normalizeLaneName(found.textContent.trim());
+            const text = getLaneTitleText(found);
             if (text) return text;
           }
         } catch (_) {}
       }
       el = el.parentElement;
     }
-    return null;
+    // Positional fallback: find the lane header whose horizontal centre is
+    // closest to this card's horizontal centre (works even when headers and
+    // cards live in separate DOM subtrees).
+    return findCardLaneByPosition(card);
+  }
+
+  // Positional lane-name lookup: aligns card x-position with header x-position.
+  function findCardLaneByPosition(card) {
+    try {
+      const cardRect = card.getBoundingClientRect();
+      if (cardRect.width === 0 && cardRect.height === 0) return null;
+      const cardCenterX = cardRect.left + cardRect.width / 2;
+      let closestName = null;
+      let minDist = Infinity;
+      for (const sel of LANE_TITLE_SELECTORS) {
+        document.querySelectorAll(sel).forEach((titleEl) => {
+          const name = getLaneTitleText(titleEl);
+          if (!name) return;
+          const r = titleEl.getBoundingClientRect();
+          if (r.width === 0 && r.height === 0) return;
+          const dist = Math.abs((r.left + r.width / 2) - cardCenterX);
+          if (dist < minDist) { minDist = dist; closestName = name; }
+        });
+        if (closestName !== null) break;
+      }
+      return closestName;
+    } catch (_) {
+      return null;
+    }
   }
 
   // Returns all unique lane names currently visible on the board.
@@ -204,12 +261,15 @@
     for (const sel of LANE_TITLE_SELECTORS) {
       try {
         document.querySelectorAll(sel).forEach((el) => {
-          const text = normalizeLaneName(el.textContent.trim());
+          const text = getLaneTitleText(el);
           if (text && !lanes.includes(text)) lanes.push(text);
         });
       } catch (_) {}
+      // Use the first selector that finds anything to avoid duplicates from
+      // broader selectors matching the same elements.
+      if (lanes.length > 0) break;
     }
-    // Fallback: derive from cards if direct header query found nothing
+    // Fallback: derive from cards if no header elements were found
     if (lanes.length === 0) {
       document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
         const lane = findCardLane(card);

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -909,10 +909,6 @@
         if (age === null) return;
         card.setAttribute('data-task-age-days', age);
         if (!config.enableAgeBadge) return;
-        if (config.wipLanes && config.wipLanes.length > 0) {
-          const laneName = findCardLane(card);
-          if (laneName !== null && !config.wipLanes.includes(laneName)) return;
-        }
         const badgeColor = getBadgeColor(age);
         const badge = createBadge(
           `Age: ${age} day${age !== 1 ? 's' : ''}`,

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.9.2 (Safari)
+  Version 0.10.0 (Safari)
   - Uses browser.* namespace (WebExtensions API) for Safari compatibility.
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
@@ -118,6 +118,13 @@
                   : cfg.defaultConfig.updateIndicator.staleEmoji,
             };
           }
+
+          if (!Array.isArray(boardCfg.wipLanes)) {
+            boardCfg.wipLanes = [];
+          }
+          if (!Array.isArray(boardCfg.lanes)) {
+            boardCfg.lanes = [];
+          }
         });
         callback(cfg);
       }).catch(function () {
@@ -152,12 +159,21 @@
     const label = document.querySelector('label.sn-navhub-title');
     if (!label) return;
     const name = label.textContent.trim();
+    const discoveredLanes = discoverLanes();
     if (!cfg.boards[boardId]) {
-      cfg.boards[boardId] = { name: name };
+      cfg.boards[boardId] = { name, lanes: discoveredLanes };
       saveConfig(cfg);
-    } else if (cfg.boards[boardId].name !== name) {
-      cfg.boards[boardId].name = name;
-      saveConfig(cfg);
+    } else {
+      let changed = false;
+      if (cfg.boards[boardId].name !== name) {
+        cfg.boards[boardId].name = name;
+        changed = true;
+      }
+      if (discoveredLanes.length > 0) {
+        cfg.boards[boardId].lanes = discoveredLanes;
+        changed = true;
+      }
+      if (changed) saveConfig(cfg);
     }
   }
 
@@ -202,6 +218,8 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      // wipLanes: empty array means show on all cards; non-empty restricts to named lanes only.
+      wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -327,6 +345,15 @@
     }
 
     function computeUpdateIndicatorState(timeElement) {
+      // When WIP lanes are configured, suppress the indicator on non-WIP cards.
+      if (config.wipLanes && config.wipLanes.length > 0) {
+        const card = timeElement.closest('.vtb-card-component-wrapper');
+        if (card) {
+          const laneName = findCardLane(card);
+          if (laneName !== null && !config.wipLanes.includes(laneName)) return null;
+        }
+      }
+
       const timestampString = getTimestampString(timeElement);
       const lastUpdated = parseServiceNowDateTime(timestampString);
       if (!lastUpdated) return null;
@@ -547,6 +574,55 @@
 
     function normalizeDateLabel(text) {
       return text.trim().replace(/\s*:\s*$/, '').toLocaleLowerCase();
+    }
+
+    // CSS selectors tried in order when searching for a lane/column title element.
+    // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+    const LANE_TITLE_SELECTORS = [
+      '.vtb-lane-header-title',
+      '.sn-board-header-title',
+      '.vtb-board-header-title',
+      '[class*="lane-header"] [class*="title"]',
+      '[class*="lane"] > [class*="header"] > [class*="title"]',
+    ];
+
+    // Returns the lane (column) name for a given card by walking up the DOM.
+    function findCardLane(card) {
+      let el = card.parentElement;
+      while (el && el !== document.body) {
+        for (const sel of LANE_TITLE_SELECTORS) {
+          try {
+            const found = el.querySelector(sel);
+            if (found) {
+              const text = found.textContent.trim();
+              if (text) return text;
+            }
+          } catch (_) {}
+        }
+        el = el.parentElement;
+      }
+      return null;
+    }
+
+    // Returns all unique lane names currently visible on the board.
+    function discoverLanes() {
+      const lanes = [];
+      for (const sel of LANE_TITLE_SELECTORS) {
+        try {
+          document.querySelectorAll(sel).forEach((el) => {
+            const text = el.textContent.trim();
+            if (text && !lanes.includes(text)) lanes.push(text);
+          });
+        } catch (_) {}
+      }
+      // Fallback: derive from cards if direct header query found nothing
+      if (lanes.length === 0) {
+        document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+          const lane = findCardLane(card);
+          if (lane && !lanes.includes(lane)) lanes.push(lane);
+        });
+      }
+      return lanes;
     }
 
     const DATE_LABELS = {

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -208,25 +208,37 @@
   }
 
   // Returns the lane (column) name for a given card by walking up the DOM.
-  // If the walk-up finds no header (e.g. lane headers and card lists are in
-  // parallel DOM branches), falls back to positional matching.
+  //
+  // Key constraint: we use querySelectorAll (not querySelector) and only accept
+  // the result when exactly ONE title element is found within the current ancestor.
+  // This prevents the common failure mode where the walk-up reaches a board-level
+  // container that holds ALL lane headers — querySelector would return the first
+  // lane in the DOM (e.g. "Backlog") for every card regardless of their actual lane.
+  // When multiple titles are found, we break the inner loop (stop trying selectors
+  // at this level) and continue to the parent, eventually falling back to positional
+  // matching if no single-lane ancestor is ever found.
   function findCardLane(card) {
     let el = card.parentElement;
     while (el && el !== document.body) {
       for (const sel of LANE_TITLE_SELECTORS) {
         try {
-          const found = el.querySelector(sel);
-          if (found) {
-            const text = getLaneTitleText(found);
+          const matches = el.querySelectorAll(sel);
+          if (matches.length === 1) {
+            const text = getLaneTitleText(matches[0]);
             if (text) return text;
+          } else if (matches.length > 1) {
+            // This ancestor spans multiple lanes — stop testing selectors here
+            // and move up to the next parent.
+            break;
           }
+          // length === 0: no title in this subtree via this selector; try next
         } catch (_) {}
       }
       el = el.parentElement;
     }
-    // Positional fallback: find the lane header whose horizontal centre is
-    // closest to this card's horizontal centre (works even when headers and
-    // cards live in separate DOM subtrees).
+    // Walk-up could not isolate a single-lane ancestor — fall back to positional
+    // matching (works for boards where headers and card columns are in parallel
+    // DOM branches, e.g. sticky-header layouts).
     return findCardLaneByPosition(card);
   }
 

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -495,15 +495,15 @@
     }
 
     function removeExistingUpdateIndicator(timeElement) {
-      const existingIndicator = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator'
-      );
-      if (existingIndicator) existingIndicator.remove();
-
-      const existingSrText = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator-text'
-      );
-      if (existingSrText) existingSrText.remove();
+      // The indicator lives on the card wrapper (not inside the time element) so
+      // that it remains visible regardless of lane-specific CSS applied to the
+      // sn-time-ago subtree.
+      const card = timeElement.closest('.vtb-card-component-wrapper');
+      if (card) {
+        card.querySelectorAll(
+          '.vtb-enhancer-update-indicator, .vtb-enhancer-update-indicator-text'
+        ).forEach((el) => el.remove());
+      }
     }
 
     function getIndicatorEmojis() {
@@ -595,17 +595,21 @@
 
     function applyUpdateIndicator(timeElement) {
       const state = computeUpdateIndicatorState(timeElement);
-      const existingIndicator = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator'
-      );
-      const existingSrText = timeElement.querySelector(
-        '.vtb-enhancer-update-indicator-text'
-      );
+
+      // Render the indicator directly on the card wrapper, not inside the
+      // sn-time-ago subtree. Some lanes (e.g. those that hide their timestamp
+      // footer until card hover) apply CSS to sn-time-ago that makes any
+      // injected children invisible until the hover state activates. Placing
+      // the indicator on the card wrapper — the same host element used by the
+      // age badge — ensures it is always visible.
+      const card = timeElement.closest('.vtb-card-component-wrapper');
+
+      const existingIndicator = card && card.querySelector('.vtb-enhancer-update-indicator');
+      const existingSrText = card && card.querySelector('.vtb-enhancer-update-indicator-text');
 
       if (!state) {
-        if (existingIndicator || existingSrText) {
-          removeExistingUpdateIndicator(timeElement);
-        }
+        if (existingIndicator) existingIndicator.remove();
+        if (existingSrText) existingSrText.remove();
         return;
       }
 
@@ -618,50 +622,44 @@
         return;
       }
 
-      removeExistingUpdateIndicator(timeElement);
+      if (existingIndicator) existingIndicator.remove();
+      if (existingSrText) existingSrText.remove();
+
+      if (!card) return;
+      if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
 
       const indicatorSpan = document.createElement('span');
       indicatorSpan.className = 'vtb-enhancer-update-indicator';
       indicatorSpan.setAttribute('aria-hidden', 'true');
-      indicatorSpan.style.marginLeft = '4px';
       indicatorSpan.textContent = state.emoji;
+      Object.assign(indicatorSpan.style, {
+        position: 'absolute',
+        bottom: '2px',
+        right: '6px',
+        zIndex: '1001',
+        fontSize: '13px',
+        lineHeight: '1',
+        pointerEvents: 'none',
+      });
 
       const srSpan = document.createElement('span');
-      srSpan.className = 'sr-only vtb-enhancer-update-indicator-text';
-      srSpan.textContent = state.srMessage;
+      srSpan.className = 'vtb-enhancer-update-indicator-text';
+      // sr-only inline equivalent so Bootstrap's class isn't required
+      srSpan.setAttribute('aria-label', state.srMessage);
+      Object.assign(srSpan.style, {
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: '0',
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0,0,0,0)',
+        whiteSpace: 'nowrap',
+        border: '0',
+      });
 
-      const visibleSpan = Array.from(timeElement.children).find(
-        (child) =>
-          child.nodeType === Node.ELEMENT_NODE &&
-          child.tagName === 'SPAN' &&
-          !child.classList.contains('sr-only') &&
-          !child.classList.contains('vtb-enhancer-update-indicator') &&
-          !child.classList.contains('vtb-enhancer-update-indicator-text')
-      );
-
-      const srOnlyReference = Array.from(timeElement.children).find(
-        (child) =>
-          child.classList &&
-          child.classList.contains('sr-only') &&
-          !child.classList.contains('vtb-enhancer-update-indicator-text')
-      );
-
-      if (visibleSpan && typeof visibleSpan.after === 'function') {
-        visibleSpan.after(indicatorSpan);
-      } else if (srOnlyReference && srOnlyReference.parentNode) {
-        srOnlyReference.parentNode.insertBefore(
-          indicatorSpan,
-          srOnlyReference
-        );
-      } else {
-        timeElement.appendChild(indicatorSpan);
-      }
-
-      if (srOnlyReference && srOnlyReference.parentNode) {
-        srOnlyReference.parentNode.insertBefore(srSpan, srOnlyReference);
-      } else {
-        indicatorSpan.after(srSpan);
-      }
+      card.appendChild(indicatorSpan);
+      card.appendChild(srSpan);
     }
 
     function detachTimeObserver(timeElement) {

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.9.2 (Safari)
+  Version 0.9.6 (Safari)
   - Uses browser.* namespace (WebExtensions API) for Safari compatibility.
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
@@ -225,9 +225,66 @@
     const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
     function calculateDaysDiff(dateStr) {
-      const d = new Date(dateStr);
-      if (isNaN(d)) return null;
+      const d = parseDisplayedDate(dateStr);
+      if (!d) return null;
       return Math.floor((Date.now() - d.getTime()) / MS_PER_DAY);
+    }
+
+    // Determines whether the browser locale uses day-first ordering (DD/MM vs MM/DD).
+    // ServiceNow respects user locale settings; browser language is the best proxy available.
+    function isDayFirstLocale() {
+      const lang = (navigator.language || navigator.userLanguage || '').toLowerCase();
+      // Only en-US and a handful of others use month-first; default to day-first for safety.
+      return !/^en-us|^en-ca|^en-au/.test(lang) || lang === '';
+    }
+
+    // Parses a date string as displayed in a ServiceNow card field, which may be localized
+    // (e.g. "15.03.2024" in German, "03/15/2024" in US English, "15/03/2024" in UK).
+    // Falls through to parseServiceNowDateTime for ISO/internal format strings.
+    function parseDisplayedDate(dateStr) {
+      if (!dateStr || typeof dateStr !== 'string') return null;
+      const trimmed = dateStr.trim();
+
+      // ISO / ServiceNow internal format first (locale-independent)
+      const snParsed = parseServiceNowDateTime(trimmed);
+      if (snParsed) return snParsed;
+
+      // DD.MM.YYYY or DD.MM.YYYY HH:MM:SS (German, Austrian, Russian, etc.)
+      const dotMatch = trimmed.match(
+        /^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/
+      );
+      if (dotMatch) {
+        const [, dd, mm, yyyy, hh = '0', mi = '0', ss = '0'] = dotMatch;
+        const d = new Date(+yyyy, +mm - 1, +dd, +hh, +mi, +ss);
+        if (!isNaN(d)) return d;
+      }
+
+      // DD-MM-YYYY or MM-DD-YYYY with time component (hyphens, locale-detected)
+      // Note: YYYY-MM-DD is already handled by parseServiceNowDateTime above.
+      const hyphenMatch = trimmed.match(
+        /^(\d{1,2})-(\d{1,2})-(\d{4})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/
+      );
+      if (hyphenMatch) {
+        const [, a, b, yyyy, hh = '0', mi = '0', ss = '0'] = hyphenMatch;
+        const [dd, mm] = +a > 12 || isDayFirstLocale() ? [+a, +b] : [+b, +a];
+        const d = new Date(+yyyy, mm - 1, dd, +hh, +mi, +ss);
+        if (!isNaN(d)) return d;
+      }
+
+      // DD/MM/YYYY or MM/DD/YYYY with optional time (locale-detected for ambiguous cases)
+      const slashMatch = trimmed.match(
+        /^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/
+      );
+      if (slashMatch) {
+        const [, a, b, yyyy, hh = '0', mi = '0', ss = '0'] = slashMatch;
+        const [dd, mm] = +a > 12 || isDayFirstLocale() ? [+a, +b] : [+b, +a];
+        const d = new Date(+yyyy, mm - 1, dd, +hh, +mi, +ss);
+        if (!isNaN(d)) return d;
+      }
+
+      // "15 Mar 2024" or "March 15, 2024" — let the engine handle these
+      const fallback = new Date(trimmed);
+      return isNaN(fallback) ? null : fallback;
     }
 
     function parseServiceNowDateTime(dateStr) {
@@ -263,8 +320,15 @@
         if (!isNaN(base)) return base;
       }
 
-      const fallback = new Date(trimmed);
-      return isNaN(fallback) ? null : fallback;
+      // YYYY-MM-DD date-only (no time component)
+      const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+      if (dateOnlyMatch) {
+        const [, year, month, day] = dateOnlyMatch.map(Number);
+        const d = new Date(year, month - 1, day);
+        if (!isNaN(d)) return d;
+      }
+
+      return null;
     }
 
     function removeExistingUpdateIndicator(timeElement) {
@@ -576,7 +640,12 @@
         );
         if (spans.length < 2) continue;
 
-        const value = spans[1].textContent.trim();
+        const valueSpan = spans[1];
+        // Prefer raw ISO value from data attributes when available — avoids locale-format issues.
+        const value =
+          valueSpan.getAttribute('data-value') ||
+          valueSpan.getAttribute('data-raw-value') ||
+          valueSpan.textContent.trim();
         if (!value) continue;
 
         const normalizedLabel = normalizeDateLabel(spans[0].textContent);

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.10.0 (Safari)
+  Version 1.0.0 (Safari)
   - Uses browser.* namespace (WebExtensions API) for Safari compatibility.
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -160,6 +160,55 @@
     }
   }
 
+  // CSS selectors tried in order when searching for a lane/column title element.
+  // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
+  const LANE_TITLE_SELECTORS = [
+    '.vtb-lane-header-title',
+    '.sn-board-header-title',
+    '.vtb-board-header-title',
+    '[class*="lane-header"] [class*="title"]',
+    '[class*="lane"] > [class*="header"] > [class*="title"]',
+  ];
+
+  // Returns the lane (column) name for a given card by walking up the DOM.
+  function findCardLane(card) {
+    let el = card.parentElement;
+    while (el && el !== document.body) {
+      for (const sel of LANE_TITLE_SELECTORS) {
+        try {
+          const found = el.querySelector(sel);
+          if (found) {
+            const text = found.textContent.trim();
+            if (text) return text;
+          }
+        } catch (_) {}
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  // Returns all unique lane names currently visible on the board.
+  function discoverLanes() {
+    const lanes = [];
+    for (const sel of LANE_TITLE_SELECTORS) {
+      try {
+        document.querySelectorAll(sel).forEach((el) => {
+          const text = el.textContent.trim();
+          if (text && !lanes.includes(text)) lanes.push(text);
+        });
+      } catch (_) {}
+    }
+    // Fallback: derive from cards if direct header query found nothing
+    if (lanes.length === 0) {
+      document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+        const lane = findCardLane(card);
+        if (lane && !lanes.includes(lane)) lanes.push(lane);
+      });
+    }
+    return lanes;
+  }
+
   function updateBoardInfo(cfg) {
     if (!boardId) return;
     // Prevent prototype pollution
@@ -651,55 +700,6 @@
 
     function normalizeDateLabel(text) {
       return text.trim().replace(/\s*:\s*$/, '').toLocaleLowerCase();
-    }
-
-    // CSS selectors tried in order when searching for a lane/column title element.
-    // ServiceNow VTB renders lanes as columns; the title is typically in a header child.
-    const LANE_TITLE_SELECTORS = [
-      '.vtb-lane-header-title',
-      '.sn-board-header-title',
-      '.vtb-board-header-title',
-      '[class*="lane-header"] [class*="title"]',
-      '[class*="lane"] > [class*="header"] > [class*="title"]',
-    ];
-
-    // Returns the lane (column) name for a given card by walking up the DOM.
-    function findCardLane(card) {
-      let el = card.parentElement;
-      while (el && el !== document.body) {
-        for (const sel of LANE_TITLE_SELECTORS) {
-          try {
-            const found = el.querySelector(sel);
-            if (found) {
-              const text = found.textContent.trim();
-              if (text) return text;
-            }
-          } catch (_) {}
-        }
-        el = el.parentElement;
-      }
-      return null;
-    }
-
-    // Returns all unique lane names currently visible on the board.
-    function discoverLanes() {
-      const lanes = [];
-      for (const sel of LANE_TITLE_SELECTORS) {
-        try {
-          document.querySelectorAll(sel).forEach((el) => {
-            const text = el.textContent.trim();
-            if (text && !lanes.includes(text)) lanes.push(text);
-          });
-        } catch (_) {}
-      }
-      // Fallback: derive from cards if direct header query found nothing
-      if (lanes.length === 0) {
-        document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
-          const lane = findCardLane(card);
-          if (lane && !lanes.includes(lane)) lanes.push(lane);
-        });
-      }
-      return lanes;
     }
 
     const DATE_LABELS = {

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -495,15 +495,15 @@
     }
 
     function removeExistingUpdateIndicator(timeElement) {
-      // The indicator lives on the card wrapper (not inside the time element) so
-      // that it remains visible regardless of lane-specific CSS applied to the
-      // sn-time-ago subtree.
-      const card = timeElement.closest('.vtb-card-component-wrapper');
-      if (card) {
-        card.querySelectorAll(
-          '.vtb-enhancer-update-indicator, .vtb-enhancer-update-indicator-text'
-        ).forEach((el) => el.remove());
-      }
+      const existingIndicator = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator'
+      );
+      if (existingIndicator) existingIndicator.remove();
+
+      const existingSrText = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator-text'
+      );
+      if (existingSrText) existingSrText.remove();
     }
 
     function getIndicatorEmojis() {
@@ -595,21 +595,17 @@
 
     function applyUpdateIndicator(timeElement) {
       const state = computeUpdateIndicatorState(timeElement);
-
-      // Render the indicator directly on the card wrapper, not inside the
-      // sn-time-ago subtree. Some lanes (e.g. those that hide their timestamp
-      // footer until card hover) apply CSS to sn-time-ago that makes any
-      // injected children invisible until the hover state activates. Placing
-      // the indicator on the card wrapper — the same host element used by the
-      // age badge — ensures it is always visible.
-      const card = timeElement.closest('.vtb-card-component-wrapper');
-
-      const existingIndicator = card && card.querySelector('.vtb-enhancer-update-indicator');
-      const existingSrText = card && card.querySelector('.vtb-enhancer-update-indicator-text');
+      const existingIndicator = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator'
+      );
+      const existingSrText = timeElement.querySelector(
+        '.vtb-enhancer-update-indicator-text'
+      );
 
       if (!state) {
-        if (existingIndicator) existingIndicator.remove();
-        if (existingSrText) existingSrText.remove();
+        if (existingIndicator || existingSrText) {
+          removeExistingUpdateIndicator(timeElement);
+        }
         return;
       }
 
@@ -622,44 +618,50 @@
         return;
       }
 
-      if (existingIndicator) existingIndicator.remove();
-      if (existingSrText) existingSrText.remove();
-
-      if (!card) return;
-      if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
+      removeExistingUpdateIndicator(timeElement);
 
       const indicatorSpan = document.createElement('span');
       indicatorSpan.className = 'vtb-enhancer-update-indicator';
       indicatorSpan.setAttribute('aria-hidden', 'true');
+      indicatorSpan.style.marginLeft = '4px';
       indicatorSpan.textContent = state.emoji;
-      Object.assign(indicatorSpan.style, {
-        position: 'absolute',
-        bottom: '2px',
-        right: '6px',
-        zIndex: '1001',
-        fontSize: '13px',
-        lineHeight: '1',
-        pointerEvents: 'none',
-      });
 
       const srSpan = document.createElement('span');
-      srSpan.className = 'vtb-enhancer-update-indicator-text';
-      // sr-only inline equivalent so Bootstrap's class isn't required
-      srSpan.setAttribute('aria-label', state.srMessage);
-      Object.assign(srSpan.style, {
-        position: 'absolute',
-        width: '1px',
-        height: '1px',
-        padding: '0',
-        margin: '-1px',
-        overflow: 'hidden',
-        clip: 'rect(0,0,0,0)',
-        whiteSpace: 'nowrap',
-        border: '0',
-      });
+      srSpan.className = 'sr-only vtb-enhancer-update-indicator-text';
+      srSpan.textContent = state.srMessage;
 
-      card.appendChild(indicatorSpan);
-      card.appendChild(srSpan);
+      const visibleSpan = Array.from(timeElement.children).find(
+        (child) =>
+          child.nodeType === Node.ELEMENT_NODE &&
+          child.tagName === 'SPAN' &&
+          !child.classList.contains('sr-only') &&
+          !child.classList.contains('vtb-enhancer-update-indicator') &&
+          !child.classList.contains('vtb-enhancer-update-indicator-text')
+      );
+
+      const srOnlyReference = Array.from(timeElement.children).find(
+        (child) =>
+          child.classList &&
+          child.classList.contains('sr-only') &&
+          !child.classList.contains('vtb-enhancer-update-indicator-text')
+      );
+
+      if (visibleSpan && typeof visibleSpan.after === 'function') {
+        visibleSpan.after(indicatorSpan);
+      } else if (srOnlyReference && srOnlyReference.parentNode) {
+        srOnlyReference.parentNode.insertBefore(
+          indicatorSpan,
+          srOnlyReference
+        );
+      } else {
+        timeElement.appendChild(indicatorSpan);
+      }
+
+      if (srOnlyReference && srOnlyReference.parentNode) {
+        srOnlyReference.parentNode.insertBefore(srSpan, srOnlyReference);
+      } else {
+        indicatorSpan.after(srSpan);
+      }
     }
 
     function detachTimeObserver(timeElement) {

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -126,8 +126,9 @@
             boardCfg.lanes = [];
           }
           if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-            boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+            boardCfg.sle = { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
           } else {
+            if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = true;
             if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
             if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
             if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
@@ -209,31 +210,31 @@
 
   // Returns the lane (column) name for a given card by walking up the DOM.
   //
-  // Key constraint: we use querySelectorAll (not querySelector) and only accept
-  // the result when exactly ONE title element is found within the current ancestor.
-  // This prevents the common failure mode where the walk-up reaches a board-level
-  // container that holds ALL lane headers — querySelector would return the first
-  // lane in the DOM (e.g. "Backlog") for every card regardless of their actual lane.
-  // When multiple titles are found, we break the inner loop (stop trying selectors
-  // at this level) and continue to the parent, eventually falling back to positional
-  // matching if no single-lane ancestor is ever found.
+  // Only the most specific selector (.vtb-lane-header-title) is used for the
+  // walk-up uniqueness check. Broader selectors like [class*="title"] match
+  // multiple elements per lane (the div, the form, the label, any input) so the
+  // length===1 check would never succeed even when we're inside a single-lane
+  // ancestor — causing false "multiple lanes" breaks and falling through to the
+  // positional fallback for every card.
+  //
+  // The walk-up stops and returns the lane name as soon as exactly one
+  // .vtb-lane-header-title is found under the current ancestor (i.e. we're
+  // inside one lane's container). If that number exceeds one we've climbed above
+  // the lane boundary and fall back to positional matching.
   function findCardLane(card) {
+    const primarySel = LANE_TITLE_SELECTORS[0]; // '.vtb-lane-header-title'
     let el = card.parentElement;
     while (el && el !== document.body) {
-      for (const sel of LANE_TITLE_SELECTORS) {
-        try {
-          const matches = el.querySelectorAll(sel);
-          if (matches.length === 1) {
-            const text = getLaneTitleText(matches[0]);
-            if (text) return text;
-          } else if (matches.length > 1) {
-            // This ancestor spans multiple lanes — stop testing selectors here
-            // and move up to the next parent.
-            break;
-          }
-          // length === 0: no title in this subtree via this selector; try next
-        } catch (_) {}
-      }
+      try {
+        const matches = el.querySelectorAll(primarySel);
+        if (matches.length === 1) {
+          const text = getLaneTitleText(matches[0]);
+          if (text) return text;
+        } else if (matches.length > 1) {
+          break; // climbed above lane boundary — multiple headers visible
+        }
+        // length === 0: header not in this subtree yet; keep walking up
+      } catch (_) {}
       el = el.parentElement;
     }
     // Walk-up could not isolate a single-lane ancestor — fall back to positional
@@ -361,7 +362,7 @@
       wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
       sle: boardConfig && boardConfig.sle
         ? boardConfig.sle
-        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
+        : { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -554,11 +555,13 @@
 
     function computeUpdateIndicatorState(timeElement) {
       // When WIP lanes are configured, suppress the indicator on non-WIP cards.
+      // Cards whose lane cannot be determined (null) are also suppressed — when
+      // WIP mode is on we default to "not a WIP lane" rather than showing on all.
       if (config.wipLanes && config.wipLanes.length > 0) {
         const card = timeElement.closest('.vtb-card-component-wrapper');
         if (card) {
           const laneName = findCardLane(card);
-          if (laneName !== null && !config.wipLanes.includes(laneName)) return null;
+          if (!config.wipLanes.includes(laneName)) return null;
         }
       }
 
@@ -870,7 +873,7 @@
 
     // Applies an SLE escalation outline and emoji prefix to a badge based on age vs SLE target.
     function applySleEscalationToBadge(badge, age, sle) {
-      if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      if (!sle || sle.enabled === false || sle.days <= 0 || !sle.showBadgeEscalation) return;
       const approachingEmoji = sle.approachingEmoji || '⚠️';
       const breachedEmoji = sle.breachedEmoji || '🔴';
       if (age >= sle.days) {
@@ -888,7 +891,7 @@
     function renderSleSummaryBar() {
       const existing = document.getElementById('vtb-enhancer-sle-bar');
       const sle = config.sle;
-      if (!sle || sle.days <= 0 || !sle.showSummary) {
+      if (!sle || sle.enabled === false || sle.days <= 0 || !sle.showSummary) {
         if (existing) existing.remove();
         return;
       }
@@ -1061,7 +1064,7 @@
             }
           });
         });
-        if (cardChanged && config.sle && config.sle.days > 0) debouncedSleUpdate();
+        if (cardChanged && config.sle && config.sle.enabled !== false && config.sle.days > 0) debouncedSleUpdate();
       });
       observer.observe(document.body, { childList: true, subtree: true });
     }

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -1,6 +1,6 @@
 /*
   ServiceNow Visual Task Board Enhancer - Work Item Age
-  Version 0.9.2 (Safari)
+  Version 0.10.0 (Safari)
   - Uses browser.* namespace (WebExtensions API) for Safari compatibility.
   - Waits until the board has fully loaded all cards (using a MutationObserver with a debounce)
     before processing any cards or displaying a status message.
@@ -118,6 +118,16 @@
                   : cfg.defaultConfig.updateIndicator.staleEmoji,
             };
           }
+
+          // Normalize SLE config
+          if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+            boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+          } else {
+            if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+            if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+            if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+            if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+          }
         });
         callback(cfg);
       }).catch(function () {
@@ -202,6 +212,9 @@
       updateIndicator: normalizedIndicator,
       enableAgeBadge,
       enableUpdateIndicator,
+      sle: boardConfig && boardConfig.sle
+        ? boardConfig.sle
+        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -628,6 +641,66 @@
       }
     }
 
+    // Applies an SLE escalation outline to a badge element based on how close age is to the SLE.
+    function applySleEscalationToBadge(badge, age, sle) {
+      if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      if (age >= sle.days) {
+        badge.style.outline = '2px solid #c0392b';
+        badge.style.outlineOffset = '2px';
+      } else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) {
+        badge.style.outline = '2px dashed #e67e22';
+        badge.style.outlineOffset = '2px';
+      }
+    }
+
+    // Reads ages stored on cards and updates (or removes) the SLE summary bar near the board title.
+    function renderSleSummaryBar() {
+      const existing = document.getElementById('vtb-enhancer-sle-bar');
+      const sle = config.sle;
+      if (!sle || sle.days <= 0 || !sle.showSummary) {
+        if (existing) existing.remove();
+        return;
+      }
+
+      let over = 0, approaching = 0;
+      document.querySelectorAll('.vtb-card-component-wrapper').forEach((card) => {
+        const ageStr = card.getAttribute('data-task-age-days');
+        if (ageStr === null) return;
+        const age = parseInt(ageStr, 10);
+        if (isNaN(age) || age < 0) return;
+        if (age >= sle.days) over++;
+        else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) approaching++;
+      });
+
+      const bar = existing || document.createElement('div');
+      bar.id = 'vtb-enhancer-sle-bar';
+      Object.assign(bar.style, {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '10px',
+        padding: '3px 10px',
+        backgroundColor: over > 0 ? '#fdecea' : '#fff8e1',
+        border: `1px solid ${over > 0 ? '#c0392b' : '#f39c12'}`,
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontWeight: '500',
+        marginLeft: '12px',
+        verticalAlign: 'middle',
+        lineHeight: '1.4',
+      });
+      bar.innerHTML =
+        `<span>SLE: ${sle.days}d</span>` +
+        `<span style="color:#c0392b;">▲ ${over} over</span>` +
+        `<span style="color:#e67e22;">⚠ ${approaching} approaching</span>`;
+
+      if (!existing) {
+        const label = document.querySelector('label.sn-navhub-title');
+        if (label && label.parentNode) {
+          label.parentNode.insertBefore(bar, label.nextSibling);
+        }
+      }
+    }
+
     function createBadge(text, bgColor) {
       const badge = document.createElement('div');
       badge.textContent = text;
@@ -695,11 +768,13 @@
           `Age: ${age} day${age !== 1 ? 's' : ''}`,
           badgeColor
         );
+        applySleEscalationToBadge(badge, age, config.sle);
         if (getComputedStyle(card).position === 'static') {
           card.style.position = 'relative';
         }
         card.appendChild(badge);
         card.setAttribute('data-task-age-enhanced', 'true');
+        card.setAttribute('data-task-age-days', age);
         updatedCount++;
       } catch (err) {
         console.error('Work Item Age Error:', err);
@@ -717,7 +792,13 @@
 
     function observeCards() {
       if (!config.enableAgeBadge && !config.enableUpdateIndicator) return;
+      let sleBarTimer = null;
+      const debouncedSleUpdate = () => {
+        if (sleBarTimer) clearTimeout(sleBarTimer);
+        sleBarTimer = setTimeout(renderSleSummaryBar, 500);
+      };
       const observer = new MutationObserver((mutations) => {
+        let cardChanged = false;
         mutations.forEach((mutation) => {
           mutation.addedNodes.forEach((node) => {
             if (node.nodeType === Node.ELEMENT_NODE) {
@@ -733,14 +814,17 @@
                   }
                 });
               }
-              if (node.classList.contains('vtb-card-component-wrapper'))
+              if (node.classList.contains('vtb-card-component-wrapper')) {
                 processCard(node);
+                cardChanged = true;
+              }
               node
                 .querySelectorAll?.('.vtb-card-component-wrapper')
-                .forEach(processCard);
+                .forEach((card) => { processCard(card); cardChanged = true; });
             }
           });
         });
+        if (cardChanged && config.sle && config.sle.days > 0) debouncedSleUpdate();
       });
       observer.observe(document.body, { childList: true, subtree: true });
     }
@@ -779,6 +863,7 @@
           return;
         }
         processExistingCards();
+        renderSleSummaryBar();
         const ageMessage = config.enableAgeBadge
           ? `Updated ${updatedCount} cards with Work Item Age`
           : 'Work Item Age badge disabled';

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -909,6 +909,10 @@
         if (age === null) return;
         card.setAttribute('data-task-age-days', age);
         if (!config.enableAgeBadge) return;
+        if (config.wipLanes && config.wipLanes.length > 0) {
+          const laneName = findCardLane(card);
+          if (laneName !== null && !config.wipLanes.includes(laneName)) return;
+        }
         const badgeColor = getBadgeColor(age);
         const badge = createBadge(
           `Age: ${age} day${age !== 1 ? 's' : ''}`,

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -126,12 +126,14 @@
             boardCfg.lanes = [];
           }
           if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-            boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+            boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
           } else {
             if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
             if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
             if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
             if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+            if (!boardCfg.sle.approachingEmoji || typeof boardCfg.sle.approachingEmoji !== 'string') boardCfg.sle.approachingEmoji = '⚠️';
+            if (!boardCfg.sle.breachedEmoji || typeof boardCfg.sle.breachedEmoji !== 'string') boardCfg.sle.breachedEmoji = '🔴';
           }
         });
         callback(cfg);
@@ -170,6 +172,14 @@
     '[class*="lane"] > [class*="header"] > [class*="title"]',
   ];
 
+  // Strips trailing card-count badges from lane header text so stored names and
+  // runtime names stay in sync even when card counts change (e.g. "In Progress (5)" → "In Progress").
+  function normalizeLaneName(text) {
+    // Prefer text from direct text nodes only (avoids child badge elements entirely).
+    // Falls back to stripping the common "(N)" suffix pattern.
+    return text.replace(/\s*\(\d+\)\s*$/, '').trim();
+  }
+
   // Returns the lane (column) name for a given card by walking up the DOM.
   function findCardLane(card) {
     let el = card.parentElement;
@@ -178,7 +188,7 @@
         try {
           const found = el.querySelector(sel);
           if (found) {
-            const text = found.textContent.trim();
+            const text = normalizeLaneName(found.textContent.trim());
             if (text) return text;
           }
         } catch (_) {}
@@ -194,7 +204,7 @@
     for (const sel of LANE_TITLE_SELECTORS) {
       try {
         document.querySelectorAll(sel).forEach((el) => {
-          const text = el.textContent.trim();
+          const text = normalizeLaneName(el.textContent.trim());
           if (text && !lanes.includes(text)) lanes.push(text);
         });
       } catch (_) {}
@@ -279,7 +289,7 @@
       wipLanes: boardConfig && Array.isArray(boardConfig.wipLanes) ? boardConfig.wipLanes : [],
       sle: boardConfig && boardConfig.sle
         ? boardConfig.sle
-        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
+        : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
     };
     // --- Utility Functions ---
     function showDebugMessage(msg) {
@@ -786,13 +796,17 @@
       }
     }
 
-    // Applies an SLE escalation outline to a badge element based on how close age is to the SLE.
+    // Applies an SLE escalation outline and emoji prefix to a badge based on age vs SLE target.
     function applySleEscalationToBadge(badge, age, sle) {
       if (!sle || sle.days <= 0 || !sle.showBadgeEscalation) return;
+      const approachingEmoji = sle.approachingEmoji || '⚠️';
+      const breachedEmoji = sle.breachedEmoji || '🔴';
       if (age >= sle.days) {
+        badge.textContent = `${breachedEmoji} ${badge.textContent}`;
         badge.style.outline = '2px solid #c0392b';
         badge.style.outlineOffset = '2px';
       } else if (sle.approachingDays > 0 && age >= sle.days - sle.approachingDays) {
+        badge.textContent = `${approachingEmoji} ${badge.textContent}`;
         badge.style.outline = '2px dashed #e67e22';
         badge.style.outlineOffset = '2px';
       }
@@ -907,13 +921,19 @@
         if (!startDate) return;
         const age = calculateDaysDiff(startDate);
         if (age === null) return;
-        card.setAttribute('data-task-age-days', age);
+        card.setAttribute('data-task-age-days', age); // Always set for SLE tracking (renderSleSummaryBar skips negative ages)
         if (!config.enableAgeBadge) return;
+        if (age < 0) {
+          // Work hasn't started yet — show how many days until the start date.
+          const badge = createBadge(`Starts in ${Math.abs(age)}d`, '#95a5a6');
+          if (getComputedStyle(card).position === 'static') card.style.position = 'relative';
+          card.appendChild(badge);
+          card.setAttribute('data-task-age-enhanced', 'true');
+          updatedCount++;
+          return;
+        }
         const badgeColor = getBadgeColor(age);
-        const badge = createBadge(
-          `Age: ${age} day${age !== 1 ? 's' : ''}`,
-          badgeColor
-        );
+        const badge = createBadge(`${age}d`, badgeColor);
         applySleEscalationToBadge(badge, age, config.sle);
         if (getComputedStyle(card).position === 'static') {
           card.style.position = 'relative';

--- a/safari-extension/content.js
+++ b/safari-extension/content.js
@@ -337,9 +337,11 @@
         if (!isNaN(parsedDate)) return parsedDate;
       }
 
-      const isoCandidate = trimmed.replace(' ', 'T');
-      const isoDate = new Date(isoCandidate);
-      if (!isNaN(isoDate)) return isoDate;
+      if (/^\d{4}[-T]/.test(trimmed)) {
+        const isoCandidate = trimmed.replace(' ', 'T');
+        const isoDate = new Date(isoCandidate);
+        if (!isNaN(isoDate)) return isoDate;
+      }
 
       const baseMatch = trimmed.match(
         /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})/
@@ -888,10 +890,9 @@
       if (card.hasAttribute('data-task-age-enhanced')) return;
       try {
         annotateLastUpdated(card);
-        if (!config.enableAgeBadge) return;
         const state = findState(card);
-        if (state) {
-          if (isCompletionState(state)) {
+        if (state && isCompletionState(state)) {
+          if (config.enableAgeBadge) {
             const badge = createBadge('Done', '#28a745');
             if (getComputedStyle(card).position === 'static') {
               card.style.position = 'relative';
@@ -899,13 +900,15 @@
             card.appendChild(badge);
             card.setAttribute('data-task-age-enhanced', 'true');
             updatedCount++;
-            return;
           }
+          return;
         }
         const startDate = findStartDate(card);
         if (!startDate) return;
         const age = calculateDaysDiff(startDate);
         if (age === null) return;
+        card.setAttribute('data-task-age-days', age);
+        if (!config.enableAgeBadge) return;
         const badgeColor = getBadgeColor(age);
         const badge = createBadge(
           `Age: ${age} day${age !== 1 ? 's' : ''}`,
@@ -917,7 +920,6 @@
         }
         card.appendChild(badge);
         card.setAttribute('data-task-age-enhanced', 'true');
-        card.setAttribute('data-task-age-days', age);
         updatedCount++;
       } catch (err) {
         console.error('Work Item Age Error:', err);

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/manifest.json
+++ b/safari-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer - Work Item Age",
-  "version": "0.9.5",
+  "version": "0.10.0",
   "description": "Displays work item age on ServiceNow Visual Task Board cards.",
   "permissions": [
     "storage"

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,15 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <!--
-      Safari version: Google Fonts CDN link removed.
-      Safari extension pages apply a strict Content Security Policy that blocks
-      external stylesheet requests by default. System fonts are used instead.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
+      rel="stylesheet"
+    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: "Roboto", sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;
@@ -259,7 +258,7 @@
       </div>
       <div class="section-title">Last Updated Freshness Indicator</div>
       <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card's last
+        When enabled, a fresh or stale emoji appears beside the card’s last
         updated timestamp (bottom right corner of each VTB card). Set the
         threshold in days to split fresh vs. stale, and pick emojis; leaving
         them blank falls back to defaults.
@@ -325,6 +324,61 @@
           </div>
         </div>
       </div>
+      <div class="section-title">Service Level Expectations</div>
+      <p class="field-help">
+        Set an SLE target (in days) for this board. When set, age badges show a
+        colored border as cards approach or exceed the target, and a summary
+        counter appears near the board title. SLE is configured per board —
+        select a board above to set its target.
+      </p>
+      <div id="sleSection">
+        <p class="field-help" id="sleDefaultHint" style="display:none;">
+          Select a specific board from the dropdown above to configure its SLE.
+        </p>
+        <div id="sleFields">
+          <div class="field-group">
+            <label for="sleDaysInput">SLE target (days, 0 = disabled):</label>
+            <input type="number" id="sleDaysInput" min="0" step="1" value="0" />
+            <p class="field-help">
+              Cards older than this many days are considered over SLE.
+            </p>
+          </div>
+          <div class="field-group">
+            <label for="sleApproachingInput">Approaching warning (days before SLE):</label>
+            <input type="number" id="sleApproachingInput" min="0" step="1" value="3" />
+            <p class="field-help">
+              Show an approaching warning when a card is within this many days of
+              the SLE target.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleSummaryToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Show board summary bar</span>
+            </div>
+            <p class="field-help">
+              Display over/approaching counts near the board title when the VTB
+              is open.
+            </p>
+          </div>
+          <div class="field-group">
+            <div class="toggle-row">
+              <label class="switch">
+                <input type="checkbox" id="sleEscalationToggle" checked />
+                <span class="slider"></span>
+              </label>
+              <span>Escalate age badge appearance near SLE</span>
+            </div>
+            <p class="field-help">
+              Add a dashed orange border (approaching) or solid red border (over)
+              to the age badge as items near the SLE target.
+            </p>
+          </div>
+        </div>
+      </div>
       <div class="actions-bar">
         <button id="saveBtn" class="btn">Save</button>
         <button id="resetBtn" class="btn btn-secondary">
@@ -336,3 +390,4 @@
     <script src="options.js"></script>
   </body>
 </html>
+

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,15 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <!--
-      Safari version: Google Fonts CDN link removed.
-      Safari extension pages apply a strict Content Security Policy that blocks
-      external stylesheet requests by default. System fonts are used instead.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
+      rel="stylesheet"
+    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: "Roboto", sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;
@@ -198,6 +197,26 @@
         color: #666;
         margin-top: 4px;
       }
+      .import-area {
+        margin-top: 12px;
+        display: none;
+      }
+      .import-area textarea {
+        width: 100%;
+        height: 160px;
+        box-sizing: border-box;
+        font-family: monospace;
+        font-size: 12px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        padding: 8px;
+        resize: vertical;
+      }
+      .import-area-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+      }
     </style>
   </head>
   <body>
@@ -259,7 +278,7 @@
       </div>
       <div class="section-title">Last Updated Freshness Indicator</div>
       <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card's last
+        When enabled, a fresh or stale emoji appears beside the card’s last
         updated timestamp (bottom right corner of each VTB card). Set the
         threshold in days to split fresh vs. stale, and pick emojis; leaving
         them blank falls back to defaults.
@@ -330,9 +349,28 @@
         <button id="resetBtn" class="btn btn-secondary">
           Reset to Default
         </button>
+        <button id="exportBtn" class="btn btn-secondary" style="display:none;">
+          Export Settings
+        </button>
+        <button id="importBtn" class="btn btn-secondary" style="display:none;">
+          Import Settings
+        </button>
+      </div>
+      <div id="importArea" class="import-area">
+        <p class="field-help">
+          Paste the JSON from a previously exported board configuration, then
+          click <strong>Apply</strong>. Only board-level settings are imported;
+          your default configuration is not affected.
+        </p>
+        <textarea id="importTextarea" placeholder='{ "vtbEnhancerBoardConfig": { ... } }'></textarea>
+        <div class="import-area-actions">
+          <button id="applyImportBtn" class="btn">Apply</button>
+          <button id="cancelImportBtn" class="btn btn-secondary">Cancel</button>
+        </div>
       </div>
       <div id="status" style="margin-top: 20px"></div>
     </div>
     <script src="options.js"></script>
   </body>
 </html>
+

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,14 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
-      rel="stylesheet"
-    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: "Roboto", sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -210,26 +210,6 @@
         font-weight: 400;
         margin: 0;
       }
-      .import-area {
-        margin-top: 12px;
-        display: none;
-      }
-      .import-area textarea {
-        width: 100%;
-        height: 160px;
-        box-sizing: border-box;
-        font-family: monospace;
-        font-size: 12px;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        padding: 8px;
-        resize: vertical;
-      }
-      .import-area-actions {
-        display: flex;
-        gap: 8px;
-        margin-top: 8px;
-      }
     </style>
   </head>
   <body>
@@ -434,18 +414,7 @@
           Import Settings
         </button>
       </div>
-      <div id="importArea" class="import-area">
-        <p class="field-help">
-          Paste the JSON from a previously exported board configuration, then
-          click <strong>Apply</strong>. Only board-level settings are imported;
-          your default configuration is not affected.
-        </p>
-        <textarea id="importTextarea" placeholder='{ "vtbEnhancerBoardConfig": { ... } }'></textarea>
-        <div class="import-area-actions">
-          <button id="applyImportBtn" class="btn">Apply</button>
-          <button id="cancelImportBtn" class="btn btn-secondary">Cancel</button>
-        </div>
-      </div>
+      <input type="file" id="importFileInput" accept=".json" style="display:none;" />
       <div id="status" style="margin-top: 20px"></div>
     </div>
     <script src="options.js"></script>

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -484,6 +484,10 @@
           <h2>Service Level Expectations (SLE)</h2>
           <p>Set a day target per board. Age badges show an emoji and border when cards approach or breach the target.</p>
         </div>
+        <label class="switch">
+          <input type="checkbox" id="sleToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
 
       <div id="sleSection" class="feature-body">

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -3,15 +3,14 @@
   <head>
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
-    <!--
-      Safari version: Google Fonts CDN link removed.
-      Safari extension pages apply a strict Content Security Policy that blocks
-      external stylesheet requests by default. System fonts are used instead.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500"
+      rel="stylesheet"
+    />
     <style>
       /* Modern UI styles */
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family: "Roboto", sans-serif;
         background-color: #f4f7f9;
         margin: 0;
         padding: 20px;
@@ -198,6 +197,23 @@
         color: #666;
         margin-top: 4px;
       }
+      .lane-checkbox-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 0;
+      }
+      .lane-checkbox-item input[type="checkbox"] {
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+      .lane-checkbox-item label {
+        cursor: pointer;
+        font-weight: 400;
+        margin: 0;
+      }
     </style>
   </head>
   <body>
@@ -259,7 +275,7 @@
       </div>
       <div class="section-title">Last Updated Freshness Indicator</div>
       <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card's last
+        When enabled, a fresh or stale emoji appears beside the card’s last
         updated timestamp (bottom right corner of each VTB card). Set the
         threshold in days to split fresh vs. stale, and pick emojis; leaving
         them blank falls back to defaults.
@@ -312,6 +328,16 @@
             fall back to the default icons.
           </p>
         </div>
+        <div class="field-group" id="wipLanesSection" style="display:none;">
+          <label>WIP Lanes:</label>
+          <p class="field-help">
+            Check the lanes where the freshness indicator should appear. Leave
+            all unchecked to show on every card regardless of lane.
+          </p>
+          <div id="wipLanesList" style="margin-top: 8px;">
+            <!-- dynamically populated by options.js -->
+          </div>
+        </div>
         <div class="preview-card" id="updatePreview">
           <div class="preview-text" style="width:100%;">
             <div style="display:flex; gap:12px; align-items:center; justify-content:space-between;">
@@ -336,3 +362,4 @@
     <script src="options.js"></script>
   </body>
 </html>
+

--- a/safari-extension/options.html
+++ b/safari-extension/options.html
@@ -4,195 +4,280 @@
     <meta charset="utf-8" />
     <title>ServiceNow VTB Enhancer Options</title>
     <style>
-      /* Modern UI styles */
+      *, *::before, *::after { box-sizing: border-box; }
+
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-        background-color: #f4f7f9;
+        background-color: #f0f4f8;
         margin: 0;
-        padding: 20px;
-        color: #333;
-      }
-      .container {
-        max-width: 600px;
-        margin: auto;
-        background: #fff;
-        padding: 30px;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        border-radius: 8px;
-      }
-      h1 {
-        text-align: center;
-        margin-bottom: 20px;
-      }
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        margin-bottom: 20px;
-      }
-      th,
-      td {
-        padding: 12px;
-        text-align: left;
-        border-bottom: 1px solid #e0e0e0;
-        vertical-align: middle;
-      }
-      th {
-        background-color: #f1f3f5;
-      }
-      input[type="number"] {
-        width: 100%;
-        padding: 8px;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-      }
-      input[type="text"] {
-        width: 100%;
-        padding: 8px;
-        box-sizing: border-box;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-      }
-      /* Style the color picker so the chosen color is clearly visible */
-      input[type="color"] {
-        width: 50px;
-        height: 50px;
-        padding: 0;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        cursor: pointer;
-      }
-      .btn {
-        background-color: #007bff;
-        color: white;
-        border: none;
-        padding: 10px 20px;
-        border-radius: 4px;
-        cursor: pointer;
+        padding: 24px 16px 48px;
+        color: #1a202c;
         font-size: 14px;
-        margin-right: 10px;
+        line-height: 1.5;
       }
-      .btn:hover {
-        background-color: #0056b3;
+
+      .page-header {
+        max-width: 660px;
+        margin: 0 auto 24px;
+        text-align: center;
       }
-      .btn-secondary {
-        background-color: #6c757d;
+      .page-header h1 {
+        font-size: 20px;
+        font-weight: 700;
+        margin: 0 0 4px;
+        color: #1a202c;
       }
-      .btn-secondary:hover {
-        background-color: #565e64;
+      .page-header p {
+        font-size: 13px;
+        color: #718096;
+        margin: 0;
       }
-      .action-btn {
-        background-color: transparent;
-        border: none;
-        color: #d9534f;
+
+      /* Board selector */
+      .board-selector {
+        max-width: 660px;
+        margin: 0 auto 20px;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        padding: 16px 20px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      .board-selector label {
+        font-weight: 600;
+        white-space: nowrap;
+        color: #2d3748;
+        font-size: 13px;
+      }
+      .board-selector select {
+        flex: 1;
+        padding: 7px 10px;
+        border: 1px solid #cbd5e0;
+        border-radius: 6px;
+        font-size: 13px;
+        color: #2d3748;
+        background: #f7fafc;
         cursor: pointer;
-        font-size: 16px;
       }
-      .field-group {
-        margin-bottom: 20px;
+      .board-selector .inherit-hint {
+        font-size: 11px;
+        color: #a0aec0;
+        white-space: nowrap;
       }
-      .field-group label {
-        display: block;
-        margin-bottom: 6px;
-        font-weight: 500;
+
+      /* Feature card */
+      .feature-card {
+        max-width: 660px;
+        margin: 0 auto 16px;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        overflow: hidden;
       }
-      .field-help {
+
+      .feature-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 20px;
+        border-bottom: 1px solid #e2e8f0;
+        background: #f7fafc;
+        gap: 12px;
+      }
+      .feature-header-text h2 {
+        font-size: 15px;
+        font-weight: 700;
+        margin: 0 0 2px;
+        color: #2d3748;
+      }
+      .feature-header-text p {
         font-size: 12px;
-        color: #666;
-        margin-top: 4px;
+        color: #718096;
+        margin: 0;
       }
+
+      /* Toggle switch */
       .switch {
         position: relative;
         display: inline-block;
-        width: 48px;
-        height: 26px;
+        width: 44px;
+        height: 24px;
+        flex-shrink: 0;
       }
-      .switch input {
-        opacity: 0;
-        width: 0;
-        height: 0;
-      }
+      .switch input { opacity: 0; width: 0; height: 0; }
       .slider {
         position: absolute;
         cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: #ccc;
+        inset: 0;
+        background-color: #cbd5e0;
         transition: 0.2s;
-        border-radius: 26px;
+        border-radius: 24px;
       }
       .slider:before {
         position: absolute;
         content: "";
-        height: 20px;
-        width: 20px;
+        height: 18px;
+        width: 18px;
         left: 3px;
         bottom: 3px;
         background-color: white;
         transition: 0.2s;
         border-radius: 50%;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+        box-shadow: 0 1px 3px rgba(0,0,0,0.25);
       }
-      input:checked + .slider {
-        background-color: #007bff;
+      input:checked + .slider { background-color: #4299e1; }
+      input:checked + .slider:before { transform: translateX(20px); }
+
+      /* Feature body */
+      .feature-body {
+        padding: 20px;
       }
-      input:checked + .slider:before {
-        transform: translateX(22px);
+
+      .field-group {
+        margin-bottom: 20px;
       }
+      .field-group:last-child { margin-bottom: 0; }
+      .field-group > label {
+        display: block;
+        font-weight: 600;
+        font-size: 13px;
+        color: #2d3748;
+        margin-bottom: 6px;
+      }
+      .field-help {
+        font-size: 11px;
+        color: #718096;
+        margin-top: 5px;
+      }
+
+      input[type="number"],
+      input[type="text"] {
+        width: 100%;
+        padding: 7px 10px;
+        border: 1px solid #cbd5e0;
+        border-radius: 6px;
+        font-size: 13px;
+        color: #2d3748;
+        background: #f7fafc;
+      }
+      input[type="number"]:focus,
+      input[type="text"]:focus {
+        outline: none;
+        border-color: #4299e1;
+        background: #fff;
+      }
+
+      input[type="color"] {
+        width: 44px;
+        height: 44px;
+        padding: 2px;
+        border: 1px solid #cbd5e0;
+        border-radius: 6px;
+        cursor: pointer;
+        background: none;
+      }
+
+      /* Two-column emoji row */
+      .emoji-row {
+        display: flex;
+        gap: 16px;
+      }
+      .emoji-row > div {
+        flex: 1;
+      }
+      .emoji-row > div > label {
+        display: block;
+        font-size: 12px;
+        color: #4a5568;
+        margin-bottom: 4px;
+      }
+
+      /* Toggle inline row */
       .toggle-row {
         display: flex;
         align-items: center;
         gap: 10px;
-        flex-wrap: wrap;
       }
-      .section-title {
-        margin: 24px 0 8px;
-        font-size: 18px;
-        font-weight: 600;
-        color: #1f2933;
+      .toggle-row span {
+        font-size: 13px;
+        color: #2d3748;
       }
-      .preview-card {
-        margin-top: 12px;
-        padding: 16px;
-        border: 1px solid #e0e0e0;
-        border-radius: 8px;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        background: linear-gradient(135deg, #f8fafc, #eef2f7);
-      }
-      .preview-badge {
-        padding: 6px 10px;
-        border-radius: 6px;
-        font-weight: 700;
-        font-size: 12px;
-        min-width: 90px;
-        text-align: center;
-      }
-      .preview-text {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
+
+      /* Age bands table */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 12px;
         font-size: 13px;
       }
-      .actions-bar {
-        position: sticky;
-        bottom: 0;
-        background: #fff;
-        padding: 12px 0 0;
-        margin-top: 20px;
-        border-top: 1px solid #e0e0e0;
-        display: flex;
-        gap: 10px;
-        justify-content: flex-start;
+      th, td {
+        padding: 9px 10px;
+        text-align: left;
+        border-bottom: 1px solid #edf2f7;
+        vertical-align: middle;
       }
-      .inherit-hint {
+      th {
+        background: #f7fafc;
+        font-weight: 600;
         font-size: 12px;
-        color: #666;
-        margin-top: 4px;
+        color: #4a5568;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
       }
+      td input[type="number"] {
+        width: 100%;
+      }
+      .action-btn {
+        background: transparent;
+        border: none;
+        color: #fc8181;
+        cursor: pointer;
+        font-size: 15px;
+        padding: 2px 6px;
+        border-radius: 4px;
+        line-height: 1;
+      }
+      .action-btn:hover { background: #fff5f5; }
+
+      /* Preview card */
+      .preview-card {
+        background: linear-gradient(135deg, #f7fafc, #edf2f7);
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 14px 16px;
+        margin-top: 16px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+      }
+      .preview-badge {
+        padding: 5px 10px;
+        border-radius: 5px;
+        font-weight: 700;
+        font-size: 12px;
+        min-width: 48px;
+        text-align: center;
+        white-space: nowrap;
+      }
+      .preview-text {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        font-size: 12px;
+        color: #4a5568;
+      }
+      .preview-text .preview-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+      }
+      .preview-text strong { color: #2d3748; }
+
+      /* WIP lane checkboxes */
       .lane-checkbox-item {
         display: flex;
         align-items: center;
@@ -200,193 +285,255 @@
         padding: 4px 0;
       }
       .lane-checkbox-item input[type="checkbox"] {
-        width: 16px;
-        height: 16px;
+        width: 15px;
+        height: 15px;
         cursor: pointer;
         flex-shrink: 0;
+        accent-color: #4299e1;
       }
       .lane-checkbox-item label {
         cursor: pointer;
-        font-weight: 400;
+        font-size: 13px;
+        color: #2d3748;
         margin: 0;
+      }
+
+      /* Hint block shown when default selected */
+      .hint-block {
+        padding: 12px 16px;
+        background: #ebf8ff;
+        border: 1px solid #bee3f8;
+        border-radius: 6px;
+        font-size: 12px;
+        color: #2b6cb0;
+      }
+
+      /* Buttons */
+      .btn {
+        background-color: #4299e1;
+        color: white;
+        border: none;
+        padding: 9px 20px;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 13px;
+        font-weight: 600;
+        transition: background 0.15s;
+      }
+      .btn:hover { background-color: #3182ce; }
+      .btn-secondary {
+        background-color: #718096;
+      }
+      .btn-secondary:hover { background-color: #4a5568; }
+      .btn-sm {
+        padding: 6px 14px;
+        font-size: 12px;
+      }
+
+      /* Sticky actions bar */
+      .actions-bar {
+        position: sticky;
+        bottom: 0;
+        max-width: 660px;
+        margin: 20px auto 0;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        padding: 14px 20px;
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        box-shadow: 0 -2px 8px rgba(0,0,0,0.06);
+      }
+
+      #status {
+        font-size: 12px;
+        color: #38a169;
+        margin-left: auto;
+      }
+
+      /* Divider between sub-sections */
+      .section-divider {
+        border: none;
+        border-top: 1px solid #edf2f7;
+        margin: 20px 0;
       }
     </style>
   </head>
   <body>
-    <div class="container">
-      <h1>ServiceNow Visual Task Board Enhancer</h1>
-      <h1>Work Item Age Options</h1>
-      <p>
-        Use the switches below to turn the Work Item Age badge and the Last
-        Updated freshness indicator on or off. Changes apply to the default
-        configuration or the selected board; boards inherit defaults unless you
-        override them here.
-      </p>
-      <div class="field-group">
-        <label for="boardSelect">Board:</label>
-        <select id="boardSelect"></select>
-        <div class="inherit-hint">
-          Boards inherit defaults unless you override settings here. Blank
-          values fall back to defaults.
+    <div class="page-header">
+      <h1>ServiceNow VTB Enhancer</h1>
+      <p>Configure work item age badges, freshness indicators, and service level expectations per board.</p>
+    </div>
+
+    <!-- Board selector -->
+    <div class="board-selector">
+      <label for="boardSelect">Board:</label>
+      <select id="boardSelect"></select>
+      <span class="inherit-hint">Boards inherit defaults unless overridden.</span>
+    </div>
+
+    <!-- ── Feature 1: Work Item Age Badge ── -->
+    <div class="feature-card">
+      <div class="feature-header">
+        <div class="feature-header-text">
+          <h2>Work Item Age Badge</h2>
+          <p>Shows a color-coded age badge on every card based on the earliest of Actual start date, Start date, or Opened.</p>
         </div>
+        <label class="switch">
+          <input type="checkbox" id="ageBadgeToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
-      <div class="section-title">Work Item Age Badge</div>
-      <p class="field-help">
-        When enabled, each card shows a colored age badge based on its earliest
-        of Actual start date, Start date, or Opened. Completed states show a
-        green "Done" badge. Edit age bands to set the color thresholds; the
-        final band covers all older items.
-      </p>
-      <div class="field-group">
-        <div class="toggle-row">
-          <label class="switch">
-            <input type="checkbox" id="ageBadgeToggle" />
-            <span class="slider"></span>
-          </label>
+
+      <div id="ageBadgeSettings" class="feature-body">
+        <div class="field-group">
+          <label>Age bands</label>
+          <p class="field-help">
+            Each band covers ages up to its Max Days value. The last band (∞) catches everything older.
+            Completed cards always show a green "Done" badge regardless of age.
+          </p>
+          <table id="ageBandsTable">
+            <thead>
+              <tr>
+                <th>Max Days</th>
+                <th>Color</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <button id="addRowBtn" class="btn btn-sm btn-secondary">+ Add band</button>
         </div>
-        <p class="field-help">
-          Shows the colored age badge (including the "Done" badge) on cards.
-        </p>
-      </div>
-      <div id="ageBadgeSettings">
-        <table id="ageBandsTable">
-          <thead>
-            <tr>
-              <th>Max Days</th>
-              <th>Color</th>
-              <th>Remove</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Age band rows will be generated here -->
-          </tbody>
-        </table>
-        <button id="addRowBtn" class="btn">Add Age Band</button>
+
         <div class="preview-card" id="agePreview">
-          <div class="preview-badge" id="previewBadge">Age: 10 days</div>
+          <div class="preview-badge" id="previewBadge">10d</div>
           <div class="preview-text">
-            <span>Sample card badge using the first matching band color.</span>
+            <span>Preview of the age badge using the first matching band color for a 10-day-old card.</span>
           </div>
         </div>
       </div>
-      <div class="section-title">Last Updated Freshness Indicator</div>
-      <p class="field-help">
-        When enabled, a fresh or stale emoji appears beside the card’s last
-        updated timestamp (bottom right corner of each VTB card). Set the
-        threshold in days to split fresh vs. stale, and pick emojis; leaving
-        them blank falls back to defaults.
-      </p>
-      <div class="field-group">
-        <div class="toggle-row">
-          <label class="switch">
-            <input type="checkbox" id="updateIndicatorToggle" />
-            <span class="slider"></span>
-          </label>
+    </div>
+
+    <!-- ── Feature 2: Last Updated Freshness Indicator ── -->
+    <div class="feature-card">
+      <div class="feature-header">
+        <div class="feature-header-text">
+          <h2>Last Updated Freshness Indicator</h2>
+          <p>Adds a fresh or stale emoji next to the "last updated" timestamp at the bottom right of each card.</p>
         </div>
-        <p class="field-help">
-          Adds the fresh/stale emoji beside the "last updated" timestamp.
-        </p>
+        <label class="switch">
+          <input type="checkbox" id="updateIndicatorToggle" />
+          <span class="slider"></span>
+        </label>
       </div>
-      <div id="updateIndicatorSettings">
+
+      <div id="updateIndicatorSettings" class="feature-body">
         <div class="field-group">
-          <label for="thresholdInput">Update threshold (days):</label>
+          <label for="thresholdInput">Freshness threshold (days)</label>
           <input type="number" id="thresholdInput" min="0" step="0.1" />
-          <p class="field-help">
-            Cards updated within this many days display the "fresh" emoji. Older
-            cards show the "stale" emoji.
-          </p>
+          <p class="field-help">Cards updated within this many days show the "fresh" emoji; older cards show the "stale" emoji.</p>
         </div>
+
+        <hr class="section-divider" />
+
         <div class="field-group">
-          <label>Update status emoji:</label>
-          <div
-            style="
-              display: flex;
-              gap: 12px;
-              flex-wrap: wrap;
-              align-items: flex-start;
-            "
-          >
-            <div style="flex: 1; min-width: 120px">
-              <label for="freshEmojiInput" style="font-weight: 400"
-                >Fresh (within threshold)</label
-              >
-              <input type="text" id="freshEmojiInput" maxlength="8" />
+          <label>Status emoji</label>
+          <div class="emoji-row">
+            <div>
+              <label for="freshEmojiInput">Fresh (within threshold)</label>
+              <input type="text" id="freshEmojiInput" maxlength="8" placeholder="✅" />
             </div>
-            <div style="flex: 1; min-width: 120px">
-              <label for="staleEmojiInput" style="font-weight: 400"
-                >Stale (over threshold)</label
-              >
-              <input type="text" id="staleEmojiInput" maxlength="8" />
+            <div>
+              <label for="staleEmojiInput">Stale (over threshold)</label>
+              <input type="text" id="staleEmojiInput" maxlength="8" placeholder="❌" />
             </div>
           </div>
-          <p class="field-help">
-            Choose the emoji shown after the "time ago" text. Leave blank to
-            fall back to the default icons.
-          </p>
+          <p class="field-help">Leave blank to use the defaults (✅ / ❌).</p>
         </div>
+
+        <hr class="section-divider" />
+
         <div class="field-group" id="wipLanesSection" style="display:none;">
-          <label>WIP Lanes:</label>
+          <label>WIP lanes</label>
           <p class="field-help">
-            Check the lanes where the freshness indicator should appear. Leave
-            all unchecked to show on every card regardless of lane.
+            Check the lanes where the freshness indicator should appear. Leave all unchecked to show it on every card regardless of lane.
           </p>
-          <div id="wipLanesList" style="margin-top: 8px;">
-            <!-- dynamically populated by options.js -->
-          </div>
+          <div id="wipLanesList" style="margin-top: 8px;"></div>
         </div>
+
         <div class="preview-card" id="updatePreview">
           <div class="preview-text" style="width:100%;">
-            <div style="display:flex; gap:12px; align-items:center; justify-content:space-between;">
+            <div class="preview-row">
               <strong>Fresh example</strong>
-              <span id="previewFresh" style="font-weight:600;">2d ago ?</span>
+              <span id="previewFresh" style="font-weight:600;">2d ago ✅</span>
             </div>
-            <div style="display:flex; gap:12px; align-items:center; justify-content:space-between;">
+            <div class="preview-row">
               <strong>Stale example</strong>
-              <span id="previewStale" style="font-weight:600;">4d ago ?</span>
+              <span id="previewStale" style="font-weight:600;">4d ago ❌</span>
             </div>
           </div>
         </div>
       </div>
-      <div class="section-title">Service Level Expectations</div>
-      <p class="field-help">
-        Set an SLE target (in days) for this board. When set, age badges show a
-        colored border as cards approach or exceed the target, and a summary
-        counter appears near the board title. SLE is configured per board —
-        select a board above to set its target.
-      </p>
-      <div id="sleSection">
-        <p class="field-help" id="sleDefaultHint" style="display:none;">
-          Select a specific board from the dropdown above to configure its SLE.
-        </p>
+    </div>
+
+    <!-- ── Feature 3: Service Level Expectations ── -->
+    <div class="feature-card">
+      <div class="feature-header">
+        <div class="feature-header-text">
+          <h2>Service Level Expectations (SLE)</h2>
+          <p>Set a day target per board. Age badges show an emoji and border when cards approach or breach the target.</p>
+        </div>
+      </div>
+
+      <div id="sleSection" class="feature-body">
+        <div class="hint-block" id="sleDefaultHint" style="display:none;">
+          SLE is configured per board — select a specific board from the dropdown above.
+        </div>
+
         <div id="sleFields">
           <div class="field-group">
-            <label for="sleDaysInput">SLE target (days, 0 = disabled):</label>
+            <label for="sleDaysInput">SLE target (days, 0 = disabled)</label>
             <input type="number" id="sleDaysInput" min="0" step="1" value="0" />
-            <p class="field-help">
-              Cards older than this many days are considered over SLE.
-            </p>
+            <p class="field-help">Cards older than this many days are considered over SLE.</p>
           </div>
+
           <div class="field-group">
-            <label for="sleApproachingInput">Approaching warning (days before SLE):</label>
+            <label for="sleApproachingInput">Approaching warning (days before target)</label>
             <input type="number" id="sleApproachingInput" min="0" step="1" value="3" />
-            <p class="field-help">
-              Show an approaching warning when a card is within this many days of
-              the SLE target.
-            </p>
+            <p class="field-help">Show an approaching warning when a card is within this many days of the SLE target.</p>
           </div>
+
+          <hr class="section-divider" />
+
+          <div class="field-group">
+            <label>SLE status emoji</label>
+            <div class="emoji-row">
+              <div>
+                <label for="sleApproachingEmojiInput">Approaching target</label>
+                <input type="text" id="sleApproachingEmojiInput" maxlength="8" placeholder="⚠️" />
+              </div>
+              <div>
+                <label for="sleBreachedEmojiInput">Breached target</label>
+                <input type="text" id="sleBreachedEmojiInput" maxlength="8" placeholder="🔴" />
+              </div>
+            </div>
+            <p class="field-help">These emojis are prepended to the age badge when escalation is enabled. Leave blank to use defaults (⚠️ / 🔴).</p>
+          </div>
+
+          <hr class="section-divider" />
+
           <div class="field-group">
             <div class="toggle-row">
               <label class="switch">
                 <input type="checkbox" id="sleSummaryToggle" checked />
                 <span class="slider"></span>
               </label>
-              <span>Show board summary bar</span>
+              <span>Show summary bar near board title</span>
             </div>
-            <p class="field-help">
-              Display over/approaching counts near the board title when the VTB
-              is open.
-            </p>
+            <p class="field-help">Displays over/approaching counts inline next to the board name when the VTB is open.</p>
           </div>
+
           <div class="field-group">
             <div class="toggle-row">
               <label class="switch">
@@ -395,29 +542,23 @@
               </label>
               <span>Escalate age badge appearance near SLE</span>
             </div>
-            <p class="field-help">
-              Add a dashed orange border (approaching) or solid red border (over)
-              to the age badge as items near the SLE target.
-            </p>
+            <p class="field-help">Adds an emoji prefix and colored border to the age badge as cards approach (dashed orange) or breach (solid red) the target.</p>
           </div>
         </div>
       </div>
-      <div class="actions-bar">
-        <button id="saveBtn" class="btn">Save</button>
-        <button id="resetBtn" class="btn btn-secondary">
-          Reset to Default
-        </button>
-        <button id="exportBtn" class="btn btn-secondary" style="display:none;">
-          Export Settings
-        </button>
-        <button id="importBtn" class="btn btn-secondary" style="display:none;">
-          Import Settings
-        </button>
-      </div>
-      <input type="file" id="importFileInput" accept=".json" style="display:none;" />
-      <div id="status" style="margin-top: 20px"></div>
     </div>
+
+    <!-- ── Actions bar ── -->
+    <div class="actions-bar">
+      <button id="saveBtn" class="btn">Save</button>
+      <button id="resetBtn" class="btn btn-secondary">Reset to Default</button>
+      <button id="exportBtn" class="btn btn-secondary" style="display:none;">Export</button>
+      <button id="importBtn" class="btn btn-secondary" style="display:none;">Import</button>
+      <span id="status"></span>
+    </div>
+
+    <input type="file" id="importFileInput" accept=".json" style="display:none;" />
+
     <script src="options.js"></script>
   </body>
 </html>
-

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -1,6 +1,3 @@
-// Safari version: uses browser.storage.sync (Promise-based WebExtensions API)
-// instead of chrome.storage.sync (callback-based Chrome API).
-
 document.addEventListener('DOMContentLoaded', function () {
   const DEFAULT_UPDATE_THRESHOLD_DAYS = 6;
   const DEFAULT_UPDATE_INDICATOR = {
@@ -46,44 +43,43 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const wipLanesSection = document.getElementById('wipLanesSection');
+  const wipLanesList = document.getElementById('wipLanesList');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from browser.storage.sync (Safari/WebExtensions) or fallback to defaults.
+  // Load config from chrome.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage }
-      ).then(function (data) {
-        let cfg = data.vtbEnhancerConfig;
-        // Migrate old format { ageBands: [...] }
-        if (cfg && cfg.ageBands) {
-          cfg = { defaultConfig: cfg, boards: {} };
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(normalizeConfigStructure(cfg));
         }
-        callback(normalizeConfigStructure(cfg));
-      }).catch(function () {
-        callback(normalizeConfigStructure(defaultStorage));
-      });
+      );
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using browser.storage.sync.
+  // Save configuration using chrome.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
-        if (callback) callback();
-      }).catch(function () {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
       });
     } else {
@@ -180,6 +176,50 @@ document.addEventListener('DOMContentLoaded', function () {
     return { freshEmoji: fresh, staleEmoji: stale };
   }
 
+  function renderWipLanes(boardId) {
+    if (!boardId) {
+      wipLanesSection.style.display = 'none';
+      return;
+    }
+    const boardCfg = fullConfig.boards[boardId];
+    const lanes = (boardCfg && Array.isArray(boardCfg.lanes)) ? boardCfg.lanes : [];
+    const wipLanes = (boardCfg && Array.isArray(boardCfg.wipLanes)) ? boardCfg.wipLanes : [];
+
+    wipLanesList.innerHTML = '';
+    if (lanes.length === 0) {
+      const hint = document.createElement('p');
+      hint.className = 'field-help';
+      hint.textContent = 'No lanes discovered yet. Visit this board in ServiceNow, then return here to configure WIP lanes.';
+      wipLanesList.appendChild(hint);
+    } else {
+      lanes.forEach((lane) => {
+        const item = document.createElement('div');
+        item.className = 'lane-checkbox-item';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        const safeId = 'lane-' + lane.replace(/[^a-z0-9]/gi, '-');
+        cb.id = safeId;
+        cb.value = lane;
+        cb.checked = wipLanes.includes(lane);
+        const lbl = document.createElement('label');
+        lbl.htmlFor = safeId;
+        lbl.textContent = lane;
+        item.appendChild(cb);
+        item.appendChild(lbl);
+        wipLanesList.appendChild(item);
+      });
+    }
+    wipLanesSection.style.display = '';
+  }
+
+  function getWipLanesFromUI() {
+    const checked = [];
+    wipLanesList.querySelectorAll('input[type="checkbox"]:checked').forEach((cb) => {
+      checked.push(cb.value);
+    });
+    return checked;
+  }
+
   function toggleSettingsVisibility() {
     const showAge = ageBadgeToggle.checked;
     const showUpdate = updateIndicatorToggle.checked;
@@ -255,6 +295,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    renderWipLanes(currentBoardId);
   }
 
   function refreshTable() {
@@ -438,6 +480,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].wipLanes = getWipLanesFromUI();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -461,6 +504,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].wipLanes;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -52,6 +52,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const sleApproachingInput = document.getElementById('sleApproachingInput');
   const sleSummaryToggle = document.getElementById('sleSummaryToggle');
   const sleEscalationToggle = document.getElementById('sleEscalationToggle');
+  const sleApproachingEmojiInput = document.getElementById('sleApproachingEmojiInput');
+  const sleBreachedEmojiInput = document.getElementById('sleBreachedEmojiInput');
   const sleDefaultHint = document.getElementById('sleDefaultHint');
   const sleFields = document.getElementById('sleFields');
 
@@ -165,12 +167,14 @@ document.addEventListener('DOMContentLoaded', function () {
           : cfg.defaultConfig.enableUpdateIndicator;
 
       if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
       } else {
         if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
         if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
         if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
         if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+        if (!boardCfg.sle.approachingEmoji || typeof boardCfg.sle.approachingEmoji !== 'string') boardCfg.sle.approachingEmoji = '⚠️';
+        if (!boardCfg.sle.breachedEmoji || typeof boardCfg.sle.breachedEmoji !== 'string') boardCfg.sle.breachedEmoji = '🔴';
       }
     });
 
@@ -248,11 +252,13 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function renderSleToUI(sle) {
-    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
     sleDaysInput.value = s.days;
     sleApproachingInput.value = s.approachingDays;
     sleSummaryToggle.checked = s.showSummary !== false;
     sleEscalationToggle.checked = s.showBadgeEscalation !== false;
+    sleApproachingEmojiInput.value = s.approachingEmoji || '⚠️';
+    sleBreachedEmojiInput.value = s.breachedEmoji || '🔴';
   }
 
   function getSleFromInputs() {
@@ -263,6 +269,8 @@ document.addEventListener('DOMContentLoaded', function () {
       approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
       showSummary: sleSummaryToggle.checked,
       showBadgeEscalation: sleEscalationToggle.checked,
+      approachingEmoji: sleApproachingEmojiInput.value.trim() || '⚠️',
+      breachedEmoji: sleBreachedEmojiInput.value.trim() || '🔴',
     };
   }
 
@@ -298,7 +306,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const color = getPreviewBandColor();
       previewBadge.style.backgroundColor = color;
       previewBadge.style.color = '#fff';
-      previewBadge.textContent = 'Age: 10 days';
+      previewBadge.textContent = '10d';
       previewBadge.style.display = '';
     } else if (previewBadge) {
       previewBadge.style.display = 'none';
@@ -517,7 +525,7 @@ document.addEventListener('DOMContentLoaded', function () {
         wipLanes: Array.isArray(board.wipLanes) ? [...board.wipLanes] : [],
         sle: board.sle && typeof board.sle === 'object'
           ? { ...board.sle }
-          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
+          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
       },
     };
     const json = JSON.stringify(payload, null, 2);
@@ -574,6 +582,8 @@ document.addEventListener('DOMContentLoaded', function () {
         approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
         showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
         showBadgeEscalation: typeof incoming.sle.showBadgeEscalation === 'boolean' ? incoming.sle.showBadgeEscalation : true,
+        approachingEmoji: typeof incoming.sle.approachingEmoji === 'string' && incoming.sle.approachingEmoji.trim() ? incoming.sle.approachingEmoji : '⚠️',
+        breachedEmoji: typeof incoming.sle.breachedEmoji === 'string' && incoming.sle.breachedEmoji.trim() ? incoming.sle.breachedEmoji : '🔴',
       };
     }
 

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -47,10 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const wipLanesList = document.getElementById('wipLanesList');
   const exportBtn = document.getElementById('exportBtn');
   const importBtn = document.getElementById('importBtn');
-  const importArea = document.getElementById('importArea');
-  const importTextarea = document.getElementById('importTextarea');
-  const applyImportBtn = document.getElementById('applyImportBtn');
-  const cancelImportBtn = document.getElementById('cancelImportBtn');
+  const importFileInput = document.getElementById('importFileInput');
   const sleDaysInput = document.getElementById('sleDaysInput');
   const sleApproachingInput = document.getElementById('sleApproachingInput');
   const sleSummaryToggle = document.getElementById('sleSummaryToggle');
@@ -499,10 +496,6 @@ document.addEventListener('DOMContentLoaded', function () {
     const show = !!currentBoardId;
     exportBtn.style.display = show ? '' : 'none';
     importBtn.style.display = show ? '' : 'none';
-    if (!show) {
-      importArea.style.display = 'none';
-      importTextarea.value = '';
-    }
   }
 
   function exportBoardConfig() {
@@ -591,27 +584,26 @@ document.addEventListener('DOMContentLoaded', function () {
   exportBtn.addEventListener('click', exportBoardConfig);
 
   importBtn.addEventListener('click', () => {
-    importArea.style.display = importArea.style.display === 'none' ? '' : 'none';
-    importTextarea.value = '';
+    importFileInput.value = '';
+    importFileInput.click();
   });
 
-  cancelImportBtn.addEventListener('click', () => {
-    importArea.style.display = 'none';
-    importTextarea.value = '';
-  });
-
-  applyImportBtn.addEventListener('click', () => {
-    const err = applyImportedConfig(importTextarea.value.trim());
-    if (err) {
-      statusDiv.textContent = err;
-    } else {
-      importArea.style.display = 'none';
-      importTextarea.value = '';
-      saveConfig(fullConfig, () => {
-        statusDiv.textContent = 'Settings imported and saved.';
-        setTimeout(() => { statusDiv.textContent = ''; }, 3000);
-      });
-    }
+  importFileInput.addEventListener('change', () => {
+    const file = importFileInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const err = applyImportedConfig(e.target.result);
+      if (err) {
+        statusDiv.textContent = err;
+      } else {
+        saveConfig(fullConfig, () => {
+          statusDiv.textContent = 'Settings imported and saved.';
+          setTimeout(() => { statusDiv.textContent = ''; }, 3000);
+        });
+      }
+    };
+    reader.readAsText(file);
   });
 
   // --- End Export / Import ---

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -61,37 +61,36 @@ document.addEventListener('DOMContentLoaded', function () {
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from chrome.storage.sync or fallback to defaults.
+  // Load config from browser.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof chrome !== 'undefined' &&
-      chrome.storage &&
-      chrome.storage.sync
+      typeof browser !== 'undefined' &&
+      browser.storage &&
+      browser.storage.sync
     ) {
-      chrome.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage },
-        function (data) {
-          let cfg = data.vtbEnhancerConfig;
-          // Migrate old format { ageBands: [...] }
-          if (cfg && cfg.ageBands) {
-            cfg = { defaultConfig: cfg, boards: {} };
-          }
-          callback(normalizeConfigStructure(cfg));
+      browser.storage.sync.get({ vtbEnhancerConfig: defaultStorage }).then(function (data) {
+        let cfg = data.vtbEnhancerConfig;
+        // Migrate old format { ageBands: [...] }
+        if (cfg && cfg.ageBands) {
+          cfg = { defaultConfig: cfg, boards: {} };
         }
-      );
+        callback(normalizeConfigStructure(cfg));
+      }).catch(function () {
+        callback(normalizeConfigStructure(defaultStorage));
+      });
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using chrome.storage.sync.
+  // Save configuration using browser.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof chrome !== 'undefined' &&
-      chrome.storage &&
-      chrome.storage.sync
+      typeof browser !== 'undefined' &&
+      browser.storage &&
+      browser.storage.sync
     ) {
-      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
+      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
         if (callback) callback();
       });
     } else {

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -521,6 +521,10 @@ document.addEventListener('DOMContentLoaded', function () {
           ? board.updateThresholdDays
           : fullConfig.defaultConfig.updateThresholdDays,
         updateIndicator: { ...normalizeIndicator(board.updateIndicator, fullConfig.defaultConfig.updateIndicator) },
+        wipLanes: Array.isArray(board.wipLanes) ? [...board.wipLanes] : [],
+        sle: board.sle && typeof board.sle === 'object'
+          ? { ...board.sle }
+          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true },
       },
     };
     const json = JSON.stringify(payload, null, 2);
@@ -567,6 +571,17 @@ document.addEventListener('DOMContentLoaded', function () {
         (b) => b && typeof b.maxDays === 'number' && b.maxDays > 0 && typeof b.color === 'string'
       );
       if (bands.length > 0) target.ageBands = bands;
+    }
+    if (Array.isArray(incoming.wipLanes)) {
+      target.wipLanes = incoming.wipLanes.filter((l) => typeof l === 'string');
+    }
+    if (incoming.sle && typeof incoming.sle === 'object') {
+      target.sle = {
+        days: typeof incoming.sle.days === 'number' && incoming.sle.days >= 0 ? incoming.sle.days : 0,
+        approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
+        showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
+        showBadgeEscalation: typeof incoming.sle.showBadgeEscalation === 'boolean' ? incoming.sle.showBadgeEscalation : true,
+      };
     }
 
     renderConfigToUI(getCurrentConfig());

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -54,6 +54,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const sleEscalationToggle = document.getElementById('sleEscalationToggle');
   const sleApproachingEmojiInput = document.getElementById('sleApproachingEmojiInput');
   const sleBreachedEmojiInput = document.getElementById('sleBreachedEmojiInput');
+  const sleToggle = document.getElementById('sleToggle');
   const sleDefaultHint = document.getElementById('sleDefaultHint');
   const sleFields = document.getElementById('sleFields');
 
@@ -167,8 +168,9 @@ document.addEventListener('DOMContentLoaded', function () {
           : cfg.defaultConfig.enableUpdateIndicator;
 
       if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
-        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+        boardCfg.sle = { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
       } else {
+        if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = true;
         if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
         if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
         if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
@@ -244,7 +246,7 @@ document.addEventListener('DOMContentLoaded', function () {
   function updateSleVisibility() {
     if (currentBoardId) {
       sleDefaultHint.style.display = 'none';
-      sleFields.style.display = '';
+      sleFields.style.display = sleToggle.checked ? '' : 'none';
     } else {
       sleDefaultHint.style.display = '';
       sleFields.style.display = 'none';
@@ -252,7 +254,8 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function renderSleToUI(sle) {
-    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+    const s = sle || { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+    sleToggle.checked = s.enabled !== false;
     sleDaysInput.value = s.days;
     sleApproachingInput.value = s.approachingDays;
     sleSummaryToggle.checked = s.showSummary !== false;
@@ -265,6 +268,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const days = parseInt(sleDaysInput.value, 10);
     const approachingDays = parseInt(sleApproachingInput.value, 10);
     return {
+      enabled: sleToggle.checked,
       days: isNaN(days) || days < 0 ? 0 : days,
       approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
       showSummary: sleSummaryToggle.checked,
@@ -352,11 +356,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     renderWipLanes(currentBoardId);
     updateExportImportVisibility();
-    updateSleVisibility();
+    // Render SLE fields first so that sleToggle.checked is set before updateSleVisibility reads it.
     if (currentBoardId) {
       const boardSle = fullConfig.boards[currentBoardId] && fullConfig.boards[currentBoardId].sle;
       renderSleToUI(boardSle);
+    } else {
+      sleToggle.checked = true;
     }
+    updateSleVisibility();
   }
 
   function refreshTable() {
@@ -525,7 +532,7 @@ document.addEventListener('DOMContentLoaded', function () {
         wipLanes: Array.isArray(board.wipLanes) ? [...board.wipLanes] : [],
         sle: board.sle && typeof board.sle === 'object'
           ? { ...board.sle }
-          : { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
+          : { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' },
       },
     };
     const json = JSON.stringify(payload, null, 2);
@@ -578,6 +585,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     if (incoming.sle && typeof incoming.sle === 'object') {
       target.sle = {
+        enabled: typeof incoming.sle.enabled === 'boolean' ? incoming.sle.enabled : true,
         days: typeof incoming.sle.days === 'number' && incoming.sle.days >= 0 ? incoming.sle.days : 0,
         approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
         showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
@@ -627,6 +635,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   ageBadgeToggle.addEventListener('change', toggleSettingsVisibility);
   updateIndicatorToggle.addEventListener('change', toggleSettingsVisibility);
+  sleToggle.addEventListener('change', updateSleVisibility);
   thresholdInput.addEventListener('input', updatePreview);
   freshEmojiInput.addEventListener('input', updatePreview);
   staleEmojiInput.addEventListener('input', updatePreview);

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -1,6 +1,3 @@
-// Safari version: uses browser.storage.sync (Promise-based WebExtensions API)
-// instead of chrome.storage.sync (callback-based Chrome API).
-
 document.addEventListener('DOMContentLoaded', function () {
   const DEFAULT_UPDATE_THRESHOLD_DAYS = 6;
   const DEFAULT_UPDATE_INDICATOR = {
@@ -46,44 +43,47 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const sleDaysInput = document.getElementById('sleDaysInput');
+  const sleApproachingInput = document.getElementById('sleApproachingInput');
+  const sleSummaryToggle = document.getElementById('sleSummaryToggle');
+  const sleEscalationToggle = document.getElementById('sleEscalationToggle');
+  const sleDefaultHint = document.getElementById('sleDefaultHint');
+  const sleFields = document.getElementById('sleFields');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from browser.storage.sync (Safari/WebExtensions) or fallback to defaults.
+  // Load config from chrome.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage }
-      ).then(function (data) {
-        let cfg = data.vtbEnhancerConfig;
-        // Migrate old format { ageBands: [...] }
-        if (cfg && cfg.ageBands) {
-          cfg = { defaultConfig: cfg, boards: {} };
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(normalizeConfigStructure(cfg));
         }
-        callback(normalizeConfigStructure(cfg));
-      }).catch(function () {
-        callback(normalizeConfigStructure(defaultStorage));
-      });
+      );
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using browser.storage.sync.
+  // Save configuration using chrome.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
-        if (callback) callback();
-      }).catch(function () {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
       });
     } else {
@@ -159,6 +159,15 @@ document.addEventListener('DOMContentLoaded', function () {
         typeof boardCfg.enableUpdateIndicator === 'boolean'
           ? boardCfg.enableUpdateIndicator
           : cfg.defaultConfig.enableUpdateIndicator;
+
+      if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
+        boardCfg.sle = { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+      } else {
+        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+        if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
+        if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
+        if (typeof boardCfg.sle.showBadgeEscalation !== 'boolean') boardCfg.sle.showBadgeEscalation = true;
+      }
     });
 
     return cfg;
@@ -178,6 +187,35 @@ document.addEventListener('DOMContentLoaded', function () {
         ? source.staleEmoji
         : base.staleEmoji;
     return { freshEmoji: fresh, staleEmoji: stale };
+  }
+
+  function updateSleVisibility() {
+    if (currentBoardId) {
+      sleDefaultHint.style.display = 'none';
+      sleFields.style.display = '';
+    } else {
+      sleDefaultHint.style.display = '';
+      sleFields.style.display = 'none';
+    }
+  }
+
+  function renderSleToUI(sle) {
+    const s = sle || { days: 0, approachingDays: 3, showSummary: true, showBadgeEscalation: true };
+    sleDaysInput.value = s.days;
+    sleApproachingInput.value = s.approachingDays;
+    sleSummaryToggle.checked = s.showSummary !== false;
+    sleEscalationToggle.checked = s.showBadgeEscalation !== false;
+  }
+
+  function getSleFromInputs() {
+    const days = parseInt(sleDaysInput.value, 10);
+    const approachingDays = parseInt(sleApproachingInput.value, 10);
+    return {
+      days: isNaN(days) || days < 0 ? 0 : days,
+      approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
+      showSummary: sleSummaryToggle.checked,
+      showBadgeEscalation: sleEscalationToggle.checked,
+    };
   }
 
   function toggleSettingsVisibility() {
@@ -255,6 +293,12 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateSleVisibility();
+    if (currentBoardId) {
+      const boardSle = fullConfig.boards[currentBoardId] && fullConfig.boards[currentBoardId].sle;
+      renderSleToUI(boardSle);
+    }
   }
 
   function refreshTable() {
@@ -398,6 +442,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateSleVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 
@@ -438,6 +483,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].ageBands = newBands;
       fullConfig.boards[currentBoardId].updateThresholdDays = thresholdValue;
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
+      fullConfig.boards[currentBoardId].sle = getSleFromInputs();
     } else {
       fullConfig.defaultConfig.enableAgeBadge = ageBadgeEnabled;
       fullConfig.defaultConfig.enableUpdateIndicator = updateIndicatorEnabled;
@@ -461,6 +507,7 @@ document.addEventListener('DOMContentLoaded', function () {
         delete fullConfig.boards[currentBoardId].updateIndicator;
         delete fullConfig.boards[currentBoardId].enableAgeBadge;
         delete fullConfig.boards[currentBoardId].enableUpdateIndicator;
+        delete fullConfig.boards[currentBoardId].sle;
       }
     } else {
       fullConfig.defaultConfig = cloneDefaultConfig();

--- a/safari-extension/options.js
+++ b/safari-extension/options.js
@@ -1,6 +1,3 @@
-// Safari version: uses browser.storage.sync (Promise-based WebExtensions API)
-// instead of chrome.storage.sync (callback-based Chrome API).
-
 document.addEventListener('DOMContentLoaded', function () {
   const DEFAULT_UPDATE_THRESHOLD_DAYS = 6;
   const DEFAULT_UPDATE_INDICATOR = {
@@ -46,44 +43,47 @@ document.addEventListener('DOMContentLoaded', function () {
   const previewBadge = document.getElementById('previewBadge');
   const previewFresh = document.getElementById('previewFresh');
   const previewStale = document.getElementById('previewStale');
+  const exportBtn = document.getElementById('exportBtn');
+  const importBtn = document.getElementById('importBtn');
+  const importArea = document.getElementById('importArea');
+  const importTextarea = document.getElementById('importTextarea');
+  const applyImportBtn = document.getElementById('applyImportBtn');
+  const cancelImportBtn = document.getElementById('cancelImportBtn');
 
   let fullConfig = null;
   let currentBoardId = null; // null means default config
 
-  // Load config from browser.storage.sync (Safari/WebExtensions) or fallback to defaults.
+  // Load config from chrome.storage.sync or fallback to defaults.
   function loadConfig(callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.get(
-        { vtbEnhancerConfig: defaultStorage }
-      ).then(function (data) {
-        let cfg = data.vtbEnhancerConfig;
-        // Migrate old format { ageBands: [...] }
-        if (cfg && cfg.ageBands) {
-          cfg = { defaultConfig: cfg, boards: {} };
+      chrome.storage.sync.get(
+        { vtbEnhancerConfig: defaultStorage },
+        function (data) {
+          let cfg = data.vtbEnhancerConfig;
+          // Migrate old format { ageBands: [...] }
+          if (cfg && cfg.ageBands) {
+            cfg = { defaultConfig: cfg, boards: {} };
+          }
+          callback(normalizeConfigStructure(cfg));
         }
-        callback(normalizeConfigStructure(cfg));
-      }).catch(function () {
-        callback(normalizeConfigStructure(defaultStorage));
-      });
+      );
     } else {
       callback(normalizeConfigStructure(defaultStorage));
     }
   }
 
-  // Save configuration using browser.storage.sync.
+  // Save configuration using chrome.storage.sync.
   function saveConfig(config, callback) {
     if (
-      typeof browser !== 'undefined' &&
-      browser.storage &&
-      browser.storage.sync
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage.sync
     ) {
-      browser.storage.sync.set({ vtbEnhancerConfig: config }).then(function () {
-        if (callback) callback();
-      }).catch(function () {
+      chrome.storage.sync.set({ vtbEnhancerConfig: config }, function () {
         if (callback) callback();
       });
     } else {
@@ -255,6 +255,8 @@ document.addEventListener('DOMContentLoaded', function () {
       const row = createRow(band);
       tableBody.appendChild(row);
     });
+
+    updateExportImportVisibility();
   }
 
   function refreshTable() {
@@ -396,8 +398,117 @@ document.addEventListener('DOMContentLoaded', function () {
     };
   }
 
+  // --- Export / Import ---
+
+  function updateExportImportVisibility() {
+    const show = !!currentBoardId;
+    exportBtn.style.display = show ? '' : 'none';
+    importBtn.style.display = show ? '' : 'none';
+    if (!show) {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+    }
+  }
+
+  function exportBoardConfig() {
+    if (!currentBoardId) return;
+    const board = fullConfig.boards[currentBoardId] || {};
+    const payload = {
+      vtbEnhancerBoardConfig: {
+        enableAgeBadge: typeof board.enableAgeBadge === 'boolean'
+          ? board.enableAgeBadge
+          : fullConfig.defaultConfig.enableAgeBadge,
+        enableUpdateIndicator: typeof board.enableUpdateIndicator === 'boolean'
+          ? board.enableUpdateIndicator
+          : fullConfig.defaultConfig.enableUpdateIndicator,
+        ageBands: (board.ageBands || fullConfig.defaultConfig.ageBands).map((b) => ({ ...b })),
+        updateThresholdDays: typeof board.updateThresholdDays === 'number'
+          ? board.updateThresholdDays
+          : fullConfig.defaultConfig.updateThresholdDays,
+        updateIndicator: { ...normalizeIndicator(board.updateIndicator, fullConfig.defaultConfig.updateIndicator) },
+      },
+    };
+    const json = JSON.stringify(payload, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    const boardName = (board.name || currentBoardId).replace(/[^a-z0-9]/gi, '-').toLowerCase();
+    a.href = url;
+    a.download = `vtb-board-config-${boardName}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  function applyImportedConfig(jsonStr) {
+    let parsed;
+    try {
+      parsed = JSON.parse(jsonStr);
+    } catch (_) {
+      return 'Invalid JSON — please check the pasted text and try again.';
+    }
+    const incoming = parsed && parsed.vtbEnhancerBoardConfig;
+    if (!incoming || typeof incoming !== 'object') {
+      return 'Unrecognised format — the JSON must contain a "vtbEnhancerBoardConfig" key.';
+    }
+    if (!currentBoardId) return 'No board selected.';
+
+    if (!fullConfig.boards[currentBoardId]) {
+      fullConfig.boards[currentBoardId] = { name: currentBoardId };
+    }
+    const target = fullConfig.boards[currentBoardId];
+
+    if (typeof incoming.enableAgeBadge === 'boolean') target.enableAgeBadge = incoming.enableAgeBadge;
+    if (typeof incoming.enableUpdateIndicator === 'boolean') target.enableUpdateIndicator = incoming.enableUpdateIndicator;
+    if (typeof incoming.updateThresholdDays === 'number' && incoming.updateThresholdDays >= 0) {
+      target.updateThresholdDays = incoming.updateThresholdDays;
+    }
+    if (incoming.updateIndicator && typeof incoming.updateIndicator === 'object') {
+      target.updateIndicator = normalizeIndicator(incoming.updateIndicator, fullConfig.defaultConfig.updateIndicator);
+    }
+    if (Array.isArray(incoming.ageBands) && incoming.ageBands.length > 0) {
+      const bands = incoming.ageBands.filter(
+        (b) => b && typeof b.maxDays === 'number' && b.maxDays > 0 && typeof b.color === 'string'
+      );
+      if (bands.length > 0) target.ageBands = bands;
+    }
+
+    renderConfigToUI(getCurrentConfig());
+    return null; // no error
+  }
+
+  exportBtn.addEventListener('click', exportBoardConfig);
+
+  importBtn.addEventListener('click', () => {
+    importArea.style.display = importArea.style.display === 'none' ? '' : 'none';
+    importTextarea.value = '';
+  });
+
+  cancelImportBtn.addEventListener('click', () => {
+    importArea.style.display = 'none';
+    importTextarea.value = '';
+  });
+
+  applyImportBtn.addEventListener('click', () => {
+    const err = applyImportedConfig(importTextarea.value.trim());
+    if (err) {
+      statusDiv.textContent = err;
+    } else {
+      importArea.style.display = 'none';
+      importTextarea.value = '';
+      saveConfig(fullConfig, () => {
+        statusDiv.textContent = 'Settings imported and saved.';
+        setTimeout(() => { statusDiv.textContent = ''; }, 3000);
+      });
+    }
+  });
+
+  // --- End Export / Import ---
+
   boardSelect.addEventListener('change', () => {
     currentBoardId = boardSelect.value || null;
+    updateExportImportVisibility();
     renderConfigToUI(getCurrentConfig());
   });
 


### PR DESCRIPTION
## Summary

- **Root cause:** ServiceNow applies `.state-hidden { opacity: 0 }` to the `sn-time-ago` element (class `sn-card-component-time`) in compact-card mode. The freshness indicator was injected inside the `<time>` child of `sn-time-ago`, so it inherited that `opacity: 0` and stayed invisible until the user hovered over the card — at which point ServiceNow's JS removed `state-hidden` and never re-added it.
- **Fix:** Move the indicator to be a **sibling of `sn-time-ago`** inside `vtb-card-component_meta_last` (the column-flex footer container) rather than a descendant of `<time>`. As a sibling it is entirely outside the opacity scope and is always visible, regardless of lane or hover state.
- **Bumps version to 1.0.1.**

## What changed

`applyUpdateIndicator` now calls `snTimeAgo.after(indicatorSpan)` instead of inserting the emoji inside `timeElement.children`. `removeExistingUpdateIndicator` was updated in parallel to look for indicator siblings of `sn-time-ago` rather than descendants of `<time>`.

The column-flex `align-items: flex-end` on `vtb-card-component_meta_last` automatically right-aligns the sibling indicator — no absolute positioning needed, no overlap with the native time-ago text or the age badge.

## Why the previous attempt was reverted

Commit `c14a45b` placed the indicator on `.vtb-card-component-wrapper` using `position: absolute; bottom: 2px; right: 6px`, which landed directly on top of the native "X ago" text. This approach avoids that by staying in the natural column-flex flow.

## Verification

Tested via a local test harness (static DOM capture of a real VTB + patched content script):
- **127/127 cards** received freshness indicators on the first pass, with no hover required
- Indicators confirmed as direct siblings of `SN-TIME-AGO` (not inside `<time>`)
- Both hidden-wrapper cards (off-screen lanes) and visible cards covered

## Test plan

- [ ] Load unpacked extension in Edge (`edge://extensions/` → Load unpacked)
- [ ] Open a VTB with an "In Flight" lane (or any lane that previously required hovering)
- [ ] Confirm freshness indicators (✅ / ❌) appear on all cards immediately, without hovering
- [ ] Confirm indicators appear correctly on Tech Review / Staging cards as before
- [ ] Confirm no visual overlap with the age badge or the native "X ago" timestamp text
- [ ] Confirm no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)