### PR TITLE
Split release workflow: separate build/release from Partner Center publication

### DIFF
--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -1,0 +1,106 @@
+name: Publish to Microsoft Edge Add-ons
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag to publish (e.g. v1.0.0)'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Download Edge zip from GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          VER="${VERSION#v}"
+          ZIP="snvtb-enhancer-edge-v${VER}.zip"
+          gh release download "${VERSION}" \
+            --repo ${{ github.repository }} \
+            --pattern "${ZIP}"
+          echo "zip=${ZIP}" >> $GITHUB_ENV
+          echo "ver=${VER}" >> $GITHUB_ENV
+
+      - name: Publish to Microsoft Edge Add-ons
+        env:
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_PRODUCT_ID: ${{ vars.EDGE_PRODUCT_ID }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          ZIP="${{ env.zip }}"
+          VER="${{ env.ver }}"
+          API="https://api.addons.microsoftedge.microsoft.com"
+
+          echo "Uploading ${ZIP} to Edge Add-ons..."
+          UPLOAD_RESP=$(curl -si \
+            -H "Authorization: ApiKey ${EDGE_API_KEY}" \
+            -H "X-ClientID: ${EDGE_CLIENT_ID}" \
+            -H "Content-Type: application/zip" \
+            -X POST \
+            -T "${ZIP}" \
+            "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions/draft/package")
+
+          HTTP_CODE=$(echo "$UPLOAD_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
+          if [ "$HTTP_CODE" != "202" ]; then
+            echo "Upload failed (HTTP $HTTP_CODE):"
+            echo "$UPLOAD_RESP"
+            exit 1
+          fi
+
+          OPERATION_ID=$(echo "$UPLOAD_RESP" | grep -i "^location:" | awk '{print $2}' | tr -d '\r' | sed 's|.*/||')
+          echo "Upload accepted, operation: ${OPERATION_ID}"
+
+          echo "Waiting for package validation..."
+          STATUS=""
+          for i in $(seq 1 24); do
+            sleep 10
+            STATUS_RESP=$(curl -s \
+              -H "Authorization: ApiKey ${EDGE_API_KEY}" \
+              -H "X-ClientID: ${EDGE_CLIENT_ID}" \
+              "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions/draft/package/operations/${OPERATION_ID}")
+            STATUS=$(echo "$STATUS_RESP" | jq -r '.status // empty')
+            echo "  Attempt ${i}/24: ${STATUS}"
+            [ "$STATUS" = "Succeeded" ] && break
+            if [ "$STATUS" = "Failed" ]; then
+              echo "Package validation failed:"
+              echo "$STATUS_RESP" | jq .
+              exit 1
+            fi
+          done
+
+          if [ "$STATUS" != "Succeeded" ]; then
+            echo "Timed out waiting for package validation after 4 minutes"
+            exit 1
+          fi
+
+          NOTES=$(gh release view "${VERSION}" --repo ${{ github.repository }} --json body -q .body 2>/dev/null \
+            || echo "Version ${VER} — see https://github.com/${{ github.repository }}/releases/tag/${VERSION}")
+
+          echo "Submitting v${VER} for Microsoft review..."
+          PUBLISH_RESP=$(curl -si \
+            -H "Authorization: ApiKey ${EDGE_API_KEY}" \
+            -H "X-ClientID: ${EDGE_CLIENT_ID}" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "{\"notes\": $(echo "$NOTES" | jq -Rs .)}" \
+            "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions")
+
+          HTTP_CODE=$(echo "$PUBLISH_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
+          if [ "$HTTP_CODE" != "202" ]; then
+            echo "Submission failed (HTTP $HTTP_CODE):"
+            echo "$PUBLISH_RESP"
+            exit 1
+          fi
+
+          echo "Successfully submitted v${VER} to Microsoft Edge Add-ons for review."
+          echo "Users will receive the update automatically after Microsoft completes their review."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -26,13 +26,6 @@ jobs:
             content.js options.html options.js manifest.json \
             images/icon16.png images/icon48.png images/icon128.png
 
-      - name: Build Safari extension zip
-        run: |
-          cd safari-extension
-          zip ../snvtb-enhancer-safari-v${{ steps.version.outputs.version }}.zip \
-            content.js options.html options.js manifest.json \
-            images/icon16.png images/icon48.png images/icon128.png
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -41,84 +34,4 @@ jobs:
           gh release create "v${VERSION}" \
             --title "v${VERSION}" \
             --generate-notes \
-            "snvtb-enhancer-edge-v${VERSION}.zip" \
-            "snvtb-enhancer-safari-v${VERSION}.zip"
-
-      - name: Publish to Microsoft Edge Add-ons
-        env:
-          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
-          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
-          EDGE_PRODUCT_ID: ${{ vars.EDGE_PRODUCT_ID }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          ZIP="snvtb-enhancer-edge-v${VERSION}.zip"
-          API="https://api.addons.microsoftedge.microsoft.com"
-
-          # Upload the package
-          echo "Uploading package to Edge Add-ons..."
-          UPLOAD_RESP=$(curl -si \
-            -H "Authorization: ApiKey ${EDGE_API_KEY}" \
-            -H "X-ClientID: ${EDGE_CLIENT_ID}" \
-            -H "Content-Type: application/zip" \
-            -X POST \
-            -T "${ZIP}" \
-            "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions/draft/package")
-
-          HTTP_CODE=$(echo "$UPLOAD_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
-          if [ "$HTTP_CODE" != "202" ]; then
-            echo "Upload failed (HTTP $HTTP_CODE):"
-            echo "$UPLOAD_RESP"
-            exit 1
-          fi
-
-          OPERATION_ID=$(echo "$UPLOAD_RESP" | grep -i "^location:" | awk '{print $2}' | tr -d '\r' | sed 's|.*/||')
-          echo "Upload accepted, operation: ${OPERATION_ID}"
-
-          # Poll until the package is validated
-          echo "Waiting for package validation..."
-          STATUS=""
-          for i in $(seq 1 24); do
-            sleep 10
-            STATUS_RESP=$(curl -s \
-              -H "Authorization: ApiKey ${EDGE_API_KEY}" \
-              -H "X-ClientID: ${EDGE_CLIENT_ID}" \
-              "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions/draft/package/operations/${OPERATION_ID}")
-            STATUS=$(echo "$STATUS_RESP" | jq -r '.status // empty')
-            echo "  Attempt ${i}/24: ${STATUS}"
-            [ "$STATUS" = "Succeeded" ] && break
-            if [ "$STATUS" = "Failed" ]; then
-              echo "Package validation failed:"
-              echo "$STATUS_RESP" | jq .
-              exit 1
-            fi
-          done
-
-          if [ "$STATUS" != "Succeeded" ]; then
-            echo "Timed out waiting for package validation after 4 minutes"
-            exit 1
-          fi
-
-          # Use GitHub Release notes as certification notes for Microsoft's review
-          NOTES=$(gh release view "v${VERSION}" --json body -q .body 2>/dev/null \
-            || echo "Version ${VERSION} — see https://github.com/mikesnowbie/SNVTBEnhancer/releases/tag/v${VERSION}")
-
-          # Submit the draft for review
-          echo "Submitting v${VERSION} for Microsoft review..."
-          PUBLISH_RESP=$(curl -si \
-            -H "Authorization: ApiKey ${EDGE_API_KEY}" \
-            -H "X-ClientID: ${EDGE_CLIENT_ID}" \
-            -H "Content-Type: application/json" \
-            -X POST \
-            -d "{\"notes\": $(echo "$NOTES" | jq -Rs .)}" \
-            "${API}/v1/products/${EDGE_PRODUCT_ID}/submissions")
-
-          HTTP_CODE=$(echo "$PUBLISH_RESP" | grep -i "^HTTP/" | tail -1 | awk '{print $2}')
-          if [ "$HTTP_CODE" != "202" ]; then
-            echo "Submission failed (HTTP $HTTP_CODE):"
-            echo "$PUBLISH_RESP"
-            exit 1
-          fi
-
-          echo "Successfully submitted v${VERSION} to Microsoft Edge Add-ons for review."
-          echo "Users will receive the update automatically after Microsoft completes their review."
+            "snvtb-enhancer-edge-v${VERSION}.zip"


### PR DESCRIPTION
## Summary

- **`release.yaml`** — stripped to build + release only. Removed the Safari zip step (Safari variant discontinued) and removed the "Publish to Microsoft Edge Add-ons" step entirely. Job renamed from `publish` to `release` to reflect its new scope.
- **`publish-edge.yaml`** (new) — `workflow_dispatch` only. Takes a version tag as input (e.g. `v1.0.0`), downloads the Edge zip from the corresponding GitHub Release, and runs the full upload → validation poll → Partner Center submission flow using the same secrets and variable (`EDGE_API_KEY`, `EDGE_CLIENT_ID`, `EDGE_PRODUCT_ID`).

This PR is intended to land on `main` **before** `release/v1.0` is merged, so the first push of that branch uses the new split workflow — no Partner Center submission happens automatically on merge.

## Why this order matters

`release/v1.0` removes `safari-extension/` and bumps to `v1.0.0`. When it merges to `main`, the release workflow will fire. With this PR already merged, that run will only build the Edge zip and create the GitHub Release. You then manually trigger `publish-edge.yaml` with `v1.0.0` when you're ready to submit to Microsoft.

## Test plan

- [ ] Merge this PR to `main` before merging `release/v1.0`
- [ ] Verify `release.yaml` no longer references Safari or Partner Center secrets
- [ ] After `release/v1.0` merges, confirm the release workflow run creates the GitHub Release with only the Edge zip and no Partner Center step
- [ ] Trigger `publish-edge.yaml` manually with `v1.0.0` and confirm it downloads the release asset and submits to Partner Center

Closes #36

---
_Generated by [Claude Code](https://claude.ai/code/session_013qnF9rLwHTvy817EQrtBUx)_