### PR TITLE
Replace pages-build-deployment with explicit Deploy GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -1,0 +1,35 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Pages
+        uses: actions/jekyll-build-pages@v1
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What changed

Replaces the auto-managed `pages-build-deployment` dynamic workflow with an explicit, well-named workflow checked into the repo.

**New file:** `.github/workflows/deploy-pages.yaml` — "Deploy GitHub Pages"

The workflow does exactly one thing: on every push to `main`, it builds the README via Jekyll and deploys it to GitHub Pages. Four steps total — checkout, jekyll build, upload artifact, deploy.

**Repo Pages source** was also switched from `legacy` to `workflow` mode (done via API ahead of this PR), so the old auto-managed workflow is already retired.

## Why

The old `pages-build-deployment` workflow was GitHub-managed (not in the repo), poorly named, and opaque. Having it as an explicit workflow file makes it visible, editable, and clearly scoped.

## Reviewer notes

- No functional change to the published site at `https://mikesnowbie.github.io/SNVTBEnhancer/` — same Jekyll build, same output.
- The `workflow_dispatch` trigger allows manual re-deploys from the Actions tab.
- `concurrency: group: pages` prevents overlapping deployments.