### PR TITLE
Fix manifest description length for Partner Center submission (1.0.1)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer",
-  "version": "1.0.0",
-  "description": "Enhances ServiceNow Visual Task Boards with work item age badges, freshness indicators, total WIP tracking, and service level expectation targets.",
+  "version": "1.0.1",
+  "description": "Enhances ServiceNow Visual Task Boards with work item age badges, freshness indicators, total WIP tracking, and SLE targets.",
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
## Problem

Microsoft Partner Center rejects the v1.0.0 package at validation with:

> The string `Enhances ServiceNow Visual Task Boards with work item age badges, freshness indicators, total WIP tracking, and service level expectation targets.` has exceeded the maximum length of 132.

The description was 146 characters — 14 over the limit.

## Fix

Replaced "service level expectation" with "SLE" (124 characters, within the 132-char limit) and bumped to 1.0.1 so the release workflow produces a corrected zip.

## After merging

1. The release workflow fires on merge and creates the v1.0.1 GitHub Release with the fixed zip.
2. Trigger `publish-edge.yaml` manually with `v1.0.1` to submit to Partner Center.

## Test plan

- [ ] Confirm `manifest.json` version is `1.0.1`
- [ ] Confirm description is ≤ 132 characters
- [ ] After merge, verify release workflow creates `snvtb-enhancer-edge-v1.0.1.zip`
- [ ] Trigger `publish-edge.yaml` with `v1.0.1` and confirm package validation passes


---
_Generated by [Claude Code](https://claude.ai/code/session_013qnF9rLwHTvy817EQrtBUx)_