### PR TITLE
Add local tool dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 
 # Local test harness — contains real board data, never commit
 test/
+
+.claude/
+.obsidian/
+docs/


### PR DESCRIPTION
## Summary

- Added `.claude/`, `.obsidian/`, and `docs/` to `.gitignore`

These directories are local-only tooling artifacts (Claude Code session files, Obsidian vault config, and a local docs folder) that should never be committed to the repo.

## Test notes

No functional code changes — `.gitignore` only. Verified the three directories no longer appear as untracked files after this change.