### PR TITLE
Fix release zip missing shared.js, popup.html, popup.js

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,10 +31,11 @@ jobs:
       - name: Build Edge extension zip
         run: |
           zip snvtb-enhancer-edge-v${{ steps.version.outputs.version }}.zip \
-            manifest.json shared.js content.js \
-            options.html options.js \
-            popup.html popup.js \
-            images/icon16.png images/icon48.png images/icon128.png
+            manifest.json \
+            *.html \
+            *.js \
+            images/icon16.png images/icon48.png images/icon128.png \
+            -x "bump-version.js" "package*.json"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,9 @@ jobs:
       - name: Build Edge extension zip
         run: |
           zip snvtb-enhancer-edge-v${{ steps.version.outputs.version }}.zip \
-            content.js options.html options.js manifest.json \
+            manifest.json shared.js content.js \
+            options.html options.js \
+            popup.html popup.js \
             images/icon16.png images/icon48.png images/icon128.png
 
       - name: Create GitHub Release

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Enhances ServiceNow Visual Task Boards with work item age badges, freshness indicators, total WIP tracking, and SLE targets.",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Problem

The `release.yaml` zip command hardcoded the original file list and was never updated when `shared.js` and `popup.html`/`popup.js` were added in v1.2.0. Edge store validation rejected the v1.2.0 upload with:

> Manifest file reference 'popup.html' does not exist in the zip archive.
> Manifest file reference 'shared.js' does not exist in the zip archive.

## Fix

Added the three missing files to the zip command:
- `shared.js` — referenced by `content_scripts` in manifest
- `popup.html` — referenced by `action.default_popup` in manifest
- `popup.js` — loaded by popup.html

## Immediate remediation for v1.2.0

A corrected zip was built locally and uploaded to replace the GitHub Release v1.2.0 asset. You can re-trigger the **Publish to Microsoft Edge Add-ons** workflow manually for `v1.2.0` — it will download the fixed zip.

## Test notes

- [ ] Merge this PR (CI will release v1.2.1 with the fixed zip command)
- [ ] Manually trigger publish-edge.yaml for `v1.2.0` to unblock the current release, OR wait for v1.2.1 to ship