### PR TITLE
Add agile_board.do support, fix freshness/SLE defaults, redesign summary bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@
 | `test/helpers.js` | Shared Playwright utilities: `launchEdge`, `navigateToBoard`, `waitForBoardEnhanced`, `setConfig` |
 | `test/playwright.config.js` | Playwright config — testDir, timeout, single worker, HTML reporter |
 | `test/explore.js` | Diagnostic script: navigates to a board, captures screenshots, dumps DOM data to `test-local/output/` |
-| `test/cases/` | Numbered assertion test files (01–07); each covers one enhancement feature |
+| `test/cases/` | Numbered assertion test files (01–08); each covers one enhancement feature |
 | `test-local/` | Gitignored runtime dir: Edge profile (auth cookies), board config, screenshots, reports |
 
 ## Git & PR Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@
 | `test/helpers.js` | Shared Playwright utilities: `launchEdge`, `navigateToBoard`, `waitForBoardEnhanced`, `setConfig` |
 | `test/playwright.config.js` | Playwright config — testDir, timeout, single worker, HTML reporter |
 | `test/explore.js` | Diagnostic script: navigates to a board, captures screenshots, dumps DOM data to `test-local/output/` |
-| `test/cases/` | Numbered assertion test files (01–06); each covers one enhancement feature |
+| `test/cases/` | Numbered assertion test files (01–07); each covers one enhancement feature |
 | `test-local/` | Gitignored runtime dir: Edge profile (auth cookies), board config, screenshots, reports |
 
 ## Git & PR Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - Vanilla JavaScript — no build step, no bundler, no framework, no npm dependencies beyond the version bump script.
 - Manifest V3 (`manifest.json`).
 - `chrome.storage.sync` for persisting per-board and global configuration.
-- The extension only runs on URLs matching `*://*.service-now.com/*vtb.do*`.
+- The extension runs on URLs matching `*://*.service-now.com/*vtb.do*` and `*://*.service-now.com/*agile_board.do*`.
 
 ## Key Files
 
@@ -25,6 +25,12 @@
 | `options.html` / `options.js` | Extension options UI (age bands, freshness threshold, emojis) |
 | `popup.html` / `popup.js` | Toolbar popup — board health dashboard and quick settings navigation |
 | `bump-version.js` | Node script that increments the patch version in `manifest.json`; runs in CI only |
+| `test/TESTING.md` | Full testing guide — setup, running tests, adding cases, troubleshooting |
+| `test/helpers.js` | Shared Playwright utilities: `launchEdge`, `navigateToBoard`, `waitForBoardEnhanced`, `setConfig` |
+| `test/playwright.config.js` | Playwright config — testDir, timeout, single worker, HTML reporter |
+| `test/explore.js` | Diagnostic script: navigates to a board, captures screenshots, dumps DOM data to `test-local/output/` |
+| `test/cases/` | Numbered assertion test files (01–06); each covers one enhancement feature |
+| `test-local/` | Gitignored runtime dir: Edge profile (auth cookies), board config, screenshots, reports |
 
 ## Git & PR Workflow
 
@@ -48,13 +54,41 @@
 
 ## Testing
 
-There are no automated tests. The extension runs inside ServiceNow, which is a live SaaS environment we cannot replicate locally. Testing means:
+The project has a **Playwright testing harness** that drives a real Microsoft Edge browser with the extension loaded against a live ServiceNow board. There is no mocked environment. See `test/TESTING.md` for the full guide.
 
-1. Loading the unpacked extension in Edge (`edge://extensions/` → Developer Mode → Load unpacked).
-2. Navigating to a real ServiceNow VTB URL (`*service-now.com/*vtb.do*`).
-3. Verifying badges render correctly, options persist, and no console errors appear.
+### Quick reference
 
-When making changes, document what was manually verified in the PR body.
+```bash
+npm install              # once per machine after pulling
+npm run test:explore     # diagnostic: screenshot + DOM dump to test-local/output/
+npm run test:assert      # run all six assertion test cases
+```
+
+The board URL is stored in **`test-local/config.json`** (gitignored — never committed):
+
+```json
+{ "testingBoardUrl": "https://YOUR-INSTANCE.service-now.com/..." }
+```
+
+### When to use each tool
+
+| Situation | Tool |
+|---|---|
+| Investigating a new board layout, unfamiliar DOM structure, or debugging why an enhancement isn't rendering | `npm run test:explore` |
+| Verifying a bug fix or new feature works end-to-end | `npm run test:assert` |
+| Testing against a different board (e.g. `agile_board.do`) | Update `testingBoardUrl` in `test-local/config.json`, then run explore first, then assert |
+
+### First-time setup
+
+1. `npm install`
+2. `mkdir -p test-local && cp test/config.example.json test-local/config.json` — fill in your board URL
+3. `npm run test:explore` — sign in when Edge opens; close once the board loads; session is saved to `test-local/.edge-profile/`
+
+### Adding a new test case
+
+Create `test/cases/07-your-feature.js`, import from `@playwright/test` and `../helpers.js`, use `helpers.launchEdge()` / `helpers.waitForBoardEnhanced()` / `helpers.setConfig()`, and call `context.close()` in `afterAll`. See `test/TESTING.md` for the full pattern.
+
+When making changes, document what was manually verified (or which test cases passed) in the PR body.
 
 ## Coding Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,20 @@
 - `chrome.storage.sync` for persisting per-board and global configuration.
 - The extension runs on URLs matching `*://*.service-now.com/*vtb.do*` and `*://*.service-now.com/*agile_board.do*`.
 
+## ServiceNow VTB DOM Architecture (important gotchas)
+
+These are non-obvious facts about how ServiceNow renders Visual Task Boards. They override naive assumptions and have each caused real bugs — read before touching card/lane/freshness logic in `content.js`.
+
+- **The board lives in a nested iframe.** The Now navigation shell loads the actual board in an inner `$vtb.do` (or `$agile_board.do`) iframe. The content script is injected with `all_frames: true` and runs inside that inner frame; the outer shell URL (`/now/nav/...`) has no board id. This is why `agile_board.do` boards "just work" — their inner frame is still `$vtb.do`. The test harness mirrors this: `getVtbFrame()` finds the inner frame, not the main frame.
+- **Off-screen cards stay in the DOM as `display:none`** (ServiceNow's `vtb-viewport-on-scroll` virtual scroll). They are *not* removed, so `document.querySelectorAll('.vtb-card-component-wrapper')` returns every card on most boards. `processExistingCards()` therefore enhances all of them at load.
+- **Per-card timestamps load lazily.** `sys_updated_on` is only bound onto a card when that card actually renders. On large/slow boards some cards are not yet rendered, so their freshness can't be computed until they are. The popup flags this via `boardCardTotal` (authoritative) vs `renderedCardCount` (see the partial-load notice in `popup.js`).
+- **Lane headers and lane bodies are SEPARATE DOM subtrees.** ServiceNow renders the header row and the card columns as parallel `ng-repeat` branches that share a `v-lane-index` attribute (and a *duplicate* `id="lane_<sysid>"`). Consequences:
+  - A card's body subtree does **not** contain its lane header, so you cannot map a card to its lane by DOM containment ("walk up to the single header") on these boards.
+  - `getBoundingClientRect`-based (geometric) lane matching returns a zero-size rect for `display:none` cards, so it silently fails for every off-screen card. This caused WIP-lane freshness to drop hidden cards.
+  - **Resolve a card's lane structurally instead:** walk up to the card's lane container and read `v-lane-index` (map it to a name via the header titles — see `getLaneIndexNameMap()`), or the lane body's `aria-label="Cards in lane: <name>"`. These work regardless of visibility. `findCardLane()` does this first, then falls back to containment, then geometry.
+- **Lane header counts are the authoritative per-lane total.** `.vtb-lane-header-count` reflects all cards in the lane including unrendered ones, so summing them (`countAllLaneCards()` / `countCardsInWipLanes()`) is more reliable than counting card DOM elements.
+- **The AngularJS model is unreachable from the content script.** `window.angular` and lane/card scopes live in the page's *main* world; the content script runs in the *isolated* world and cannot read them. Diagnostics via Playwright `frame.evaluate()` run in the main world and *can* see `angular` — do not assume the extension has the same access. Always derive runtime data from the DOM, not the Angular model.
+
 ## Key Files
 
 | File | Purpose |
@@ -61,7 +75,7 @@ The project has a **Playwright testing harness** that drives a real Microsoft Ed
 ```bash
 npm install              # once per machine after pulling
 npm run test:explore     # diagnostic: screenshot + DOM dump to test-local/output/
-npm run test:assert      # run all six assertion test cases
+npm run test:assert      # run all assertion test cases (test/cases/)
 ```
 
 The board URL is stored in **`test-local/config.json`** (gitignored — never committed):
@@ -86,7 +100,7 @@ The board URL is stored in **`test-local/config.json`** (gitignored — never co
 
 ### Adding a new test case
 
-Create `test/cases/07-your-feature.js`, import from `@playwright/test` and `../helpers.js`, use `helpers.launchEdge()` / `helpers.waitForBoardEnhanced()` / `helpers.setConfig()`, and call `context.close()` in `afterAll`. See `test/TESTING.md` for the full pattern.
+Create `test/cases/NN-your-feature.js` (next number in sequence), import from `@playwright/test` and `../helpers.js`, use `helpers.launchEdge()` / `helpers.waitForBoardEnhanced()` / `helpers.setConfig()` / `helpers.queryPopup()`, and call `context.close()` in `afterAll`. See `test/TESTING.md` for the full pattern.
 
 When making changes, document what was manually verified (or which test cases passed) in the PR body.
 

--- a/content.js
+++ b/content.js
@@ -748,7 +748,11 @@
     // lane) for the designated WIP lanes and sums them. This is more reliable than counting
     // card DOM elements ourselves because ServiceNow tracks all cards in each lane — including
     // those hidden off-screen by the virtual scroll — and keeps this count current.
-    function countCardsInWipLanes(wipLaneNames) {
+    // Sums the per-lane card counts ServiceNow renders in each lane header for
+    // every lane whose name passes includeLane(). The lane header count reflects
+    // all cards in the lane — including those not yet rendered by the virtual
+    // scroll — so it is the authoritative board total even before cards load.
+    function sumLaneCardCounts(includeLane) {
       let total = 0;
 
       for (const sel of LANE_TITLE_SELECTORS) {
@@ -756,7 +760,7 @@
         try {
           document.querySelectorAll(sel).forEach((titleEl) => {
             const name = getLaneTitleText(titleEl);
-            if (!name || !wipLaneNames.includes(name)) return;
+            if (!name || !includeLane(name)) return;
 
             // Walk up from the lane title to find the lane header container that also
             // holds the count element as a sibling. Stop before climbing above the lane
@@ -783,6 +787,18 @@
         if (anyFound) break;
       }
       return total;
+    }
+
+    function countCardsInWipLanes(wipLaneNames) {
+      return sumLaneCardCounts((name) => wipLaneNames.includes(name));
+    }
+
+    // Authoritative total card count across every lane, from the lane header
+    // counts. Used to detect when the board has not finished rendering all
+    // cards (rendered card wrappers < this total), so the popup can flag that
+    // its tallies are still partial. Returns 0 if no lane counts are found.
+    function countAllLaneCards() {
+      return sumLaneCardCounts(() => true);
     }
 
     // Renders (or removes) the summary bar near the board title for SLE and/or Total WIP.
@@ -1184,6 +1200,13 @@
           liveConfig.updateIndicator, VTBShared.DEFAULT_UPDATE_INDICATOR
         );
 
+        // Authoritative board total from the lane header counts, and how many
+        // cards are actually rendered. When ServiceNow has not finished
+        // rendering every lane's cards, renderedCardCount < boardCardTotal and
+        // all tallies above are still partial — the popup surfaces this.
+        const boardCardTotal = countAllLaneCards();
+        const renderedCardCount = cards.length;
+
         sendResponse({
           boardLoaded,
           boardId,
@@ -1205,6 +1228,8 @@
           approachingEmoji: sle ? (sle.approachingEmoji || '⚠️') : '⚠️',
           breachedEmoji: sle ? (sle.breachedEmoji || '🔴') : '🔴',
           updateThresholdDays: threshold,
+          boardCardTotal,
+          renderedCardCount,
         });
       });
       return true; // async — keep the response channel open for the loadConfig callback

--- a/content.js
+++ b/content.js
@@ -11,9 +11,11 @@
     configurable day target via badge emoji, colored border, and summary bar counts.
 */
 (function () {
-  if (!window.location.href.includes('vtb.do')) return;
+  const href = window.location.href;
+  if (!href.includes('vtb.do') && !href.includes('agile_board.do')) return;
 
-  const boardIdMatch = window.location.pathname.includes('$vtb.do')
+  const isVtbUrl = window.location.pathname.includes('$vtb.do') || window.location.pathname.includes('agile_board.do');
+  const boardIdMatch = isVtbUrl
     ? window.location.search.match(/[?&]sysparm_board=([^&]+)/)
     : null;
   const boardId = boardIdMatch ? boardIdMatch[1] : null;

--- a/content.js
+++ b/content.js
@@ -874,47 +874,50 @@
       }
       const wipCount = wipActive ? countCardsInWipLanes(totalWip.lanes) : 0;
 
+      const pillBase = 'display:inline-flex;align-items:center;border-radius:20px;padding:3px 12px;font-size:12px;font-weight:500;white-space:nowrap;line-height:1.4;';
+      const pillNeutral = pillBase + 'background:#f0f4f8;border:1px solid #e2e8f0;color:#4a5568;';
+      const pillRed = pillBase + 'background:#fdecea;border:1px solid #e9a0a0;color:#a32d2d;';
+      const pillAmber = pillBase + 'background:#fef3c7;border:1px solid #fbbf24;color:#854f0b;';
+
       const parts = [];
-      if (wipActive) parts.push(`<span><strong>Total WIP: ${wipCount}</strong></span>`);
+      if (wipActive) {
+        parts.push(`<span style="${pillNeutral}">Total WIP · ${wipCount}</span>`);
+      }
       if (sleActive) {
         const showEmojis = sle.showBadgeEmojis !== false;
-        const showBorder = sle.showBadgeBorder !== false;
         const breachedSymbol = showEmojis ? escHtml(sle.breachedEmoji || '🔴') : '▲';
         const approachingSymbol = showEmojis ? escHtml(sle.approachingEmoji || '⚠️') : '⚠';
-        const breachedStyle = 'color:#c0392b;' +
-          (showBorder ? ' outline:2px solid #c0392b; outline-offset:2px; border-radius:4px; padding:1px 6px;' : '');
-        const approachingStyle = 'color:#e67e22;' +
-          (showBorder ? ' outline:2px dashed #e67e22; outline-offset:2px; border-radius:4px; padding:1px 6px;' : '');
-        parts.push(`<span>SLE: ${sle.days}d</span>`);
-        parts.push(`<span style="${breachedStyle}">${breachedSymbol} ${over} breached</span>`);
-        parts.push(`<span style="${approachingStyle}">${approachingSymbol} ${approaching} approaching</span>`);
+        parts.push(`<span style="${pillNeutral}">SLE · ${sle.days}d</span>`);
+        parts.push(`<span style="${over > 0 ? pillRed : pillNeutral}">${breachedSymbol} ${over} breached</span>`);
+        parts.push(`<span style="${approaching > 0 ? pillAmber : pillNeutral}">${approachingSymbol} ${approaching} approaching</span>`);
       }
-
-      const bgColor = sleActive && over > 0 ? '#fdecea' : sleActive ? '#fff8e1' : '#ebf8ff';
-      const borderColor = sleActive && over > 0 ? '#c0392b' : sleActive ? '#f39c12' : '#bee3f8';
 
       const bar = existing || document.createElement('div');
       bar.id = 'vtb-enhancer-sle-bar';
-      Object.assign(bar.style, {
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: '10px',
-        padding: '6px 10px',
-        backgroundColor: bgColor,
-        border: `1px solid ${borderColor}`,
-        borderRadius: '4px',
-        fontSize: '12px',
-        fontWeight: '500',
-        marginLeft: '12px',
-        verticalAlign: 'middle',
-        lineHeight: '1.4',
-      });
+      bar.style.cssText = 'display:inline-flex;align-items:center;gap:6px;margin-left:12px;vertical-align:middle;align-self:center;';
       bar.innerHTML = parts.join('');
 
       if (!existing) {
         const label = document.querySelector('label.sn-navhub-title');
-        if (label && label.parentNode) {
-          label.parentNode.insertBefore(bar, label.nextSibling);
+        if (label) {
+          // Walk up from the label past at least one level, then continue until
+          // we find an ancestor whose parent is a horizontal flex container.
+          // That ancestor is the "title section" (board name + "Freeform Board"
+          // subtitle as a unit). Inserting the bar as a peer of the title section
+          // in the outer flex row lets the row's alignment center the bar across
+          // the full two-line height, matching the filter controls on the right.
+          let titleSection = label.parentElement && label.parentElement.parentElement;
+          while (titleSection && titleSection.parentElement && titleSection.parentElement !== document.body) {
+            try {
+              const ps = window.getComputedStyle(titleSection.parentElement);
+              const dir = ps.flexDirection || 'row';
+              if ((ps.display === 'flex' || ps.display === 'inline-flex') && !dir.includes('column')) break;
+            } catch (_) {}
+            titleSection = titleSection.parentElement;
+          }
+          const host = titleSection && titleSection.parentElement ? titleSection.parentElement : label.parentNode;
+          const ref  = titleSection && titleSection.parentElement ? titleSection : label;
+          host.insertBefore(bar, ref.nextSibling);
         }
       }
     }

--- a/content.js
+++ b/content.js
@@ -82,11 +82,55 @@
   // .vtb-lane-header-title is found under the current ancestor (i.e. we're
   // inside one lane's container). If that number exceeds one we've climbed above
   // the lane boundary and fall back to positional matching.
+  // Maps each lane's positional index (the v-lane-index attribute ServiceNow
+  // puts on both the header-side and body-side lane elements) to its display
+  // name, read from the lane header titles. ServiceNow renders lane headers and
+  // lane bodies as separate DOM subtrees that share v-lane-index / lane id, so a
+  // card's body subtree contains no header to read directly. Cached and rebuilt
+  // when the lane count changes.
+  let laneIndexNameCache = null;
+  let laneIndexNameCacheCount = -1;
+  function getLaneIndexNameMap() {
+    const headers = document.querySelectorAll(LANE_TITLE_SELECTORS[0]);
+    if (laneIndexNameCache && laneIndexNameCacheCount === headers.length) {
+      return laneIndexNameCache;
+    }
+    const map = Object.create(null);
+    headers.forEach((titleEl) => {
+      let el = titleEl;
+      while (el && el !== document.body) {
+        const idx = el.getAttribute && el.getAttribute('v-lane-index');
+        if (idx) {
+          const name = getLaneTitleText(titleEl);
+          if (name) map[idx] = name;
+          break;
+        }
+        el = el.parentElement;
+      }
+    });
+    laneIndexNameCache = map;
+    laneIndexNameCacheCount = headers.length;
+    return map;
+  }
+
   function findCardLane(card) {
+    const indexMap = getLaneIndexNameMap();
     const primarySel = LANE_TITLE_SELECTORS[0]; // '.vtb-lane-header-title'
     let el = card.parentElement;
     while (el && el !== document.body) {
       try {
+        if (el.getAttribute) {
+          // Structural markers on the card's lane container — these work even
+          // when the card is scrolled off-screen (display:none → no geometry),
+          // which positional matching cannot handle.
+          const idx = el.getAttribute('v-lane-index');
+          if (idx && indexMap[idx]) return indexMap[idx];
+          const ariaLabel = el.getAttribute('aria-label');
+          if (ariaLabel) {
+            const m = ariaLabel.match(/^Cards in lane:\s*(.+)$/);
+            if (m) return m[1].trim();
+          }
+        }
         const matches = el.querySelectorAll(primarySel);
         if (matches.length === 1) {
           const text = getLaneTitleText(matches[0]);
@@ -98,9 +142,9 @@
       } catch (_) {}
       el = el.parentElement;
     }
-    // Walk-up could not isolate a single-lane ancestor — fall back to positional
+    // Walk-up could not isolate the lane structurally — fall back to positional
     // matching (works for boards where headers and card columns are in parallel
-    // DOM branches, e.g. sticky-header layouts).
+    // DOM branches, e.g. sticky-header layouts, for cards currently on-screen).
     return findCardLaneByPosition(card);
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ServiceNow Visual Task Board Enhancer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Enhances ServiceNow Visual Task Boards with work item age badges, freshness indicators, total WIP tracking, and SLE targets.",
   "permissions": [
     "storage",
@@ -18,7 +18,8 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.service-now.com/*vtb.do*"
+        "*://*.service-now.com/*vtb.do*",
+        "*://*.service-now.com/*agile_board.do*"
       ],
       "js": [
         "shared.js",

--- a/options.js
+++ b/options.js
@@ -103,7 +103,7 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function renderSleToUI(sle) {
-    const s = sle || { enabled: true, days: 0, approachingDays: 3, showSummary: true, showBadgeEmojis: true, showBadgeBorder: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
+    const s = sle || { enabled: false, days: 7, approachingDays: 3, showSummary: true, showBadgeEmojis: true, showBadgeBorder: true, approachingEmoji: '⚠️', breachedEmoji: '🔴' };
     sleToggle.checked = s.enabled !== false;
     sleDaysInput.value = s.days;
     sleApproachingInput.value = s.approachingDays;
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const approachingDays = parseInt(sleApproachingInput.value, 10);
     return {
       enabled: sleToggle.checked,
-      days: isNaN(days) || days < 0 ? 0 : days,
+      days: isNaN(days) || days < 1 ? 7 : days,
       approachingDays: isNaN(approachingDays) || approachingDays < 0 ? 3 : approachingDays,
       showSummary: sleSummaryToggle.checked,
       showBadgeEmojis: sleEmojiToggle.checked,
@@ -504,6 +504,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const enableAgeBadgePrefix = ageBadgePrefixToggle.checked;
     const ageBadgePrefix = (ageBadgePrefixInput.value || '').trimEnd();
     if (currentBoardId) {
+      const sleValues = getSleFromInputs();
+      if (sleValues.enabled && sleValues.days < 1) {
+        statusDiv.textContent = 'SLE target must be greater than 0 when SLE is enabled.';
+        sleDaysInput.focus();
+        return;
+      }
+
       if (!fullConfig.boards[currentBoardId]) {
         fullConfig.boards[currentBoardId] = {
           name: boardSelect.options[boardSelect.selectedIndex].text,
@@ -518,7 +525,7 @@ document.addEventListener('DOMContentLoaded', function () {
       fullConfig.boards[currentBoardId].updateIndicator = indicatorValue;
       fullConfig.boards[currentBoardId].enableWipLanes = wipLanesToggle.checked;
       fullConfig.boards[currentBoardId].wipLanes = getWipLanesFromUI();
-      fullConfig.boards[currentBoardId].sle = getSleFromInputs();
+      fullConfig.boards[currentBoardId].sle = sleValues;
       fullConfig.boards[currentBoardId].totalWip = {
         enabled: totalWipToggle.checked,
         lanes: getTotalWipFromUI(),

--- a/options.js
+++ b/options.js
@@ -504,12 +504,15 @@ document.addEventListener('DOMContentLoaded', function () {
     const enableAgeBadgePrefix = ageBadgePrefixToggle.checked;
     const ageBadgePrefix = (ageBadgePrefixInput.value || '').trimEnd();
     if (currentBoardId) {
-      const sleValues = getSleFromInputs();
-      if (sleValues.enabled && sleValues.days < 1) {
-        statusDiv.textContent = 'SLE target must be greater than 0 when SLE is enabled.';
-        sleDaysInput.focus();
-        return;
+      if (sleToggle.checked) {
+        const rawSleDays = parseInt(sleDaysInput.value, 10);
+        if (isNaN(rawSleDays) || rawSleDays < 1) {
+          statusDiv.textContent = 'SLE target must be greater than 0 when SLE is enabled.';
+          sleDaysInput.focus();
+          return;
+        }
       }
+      const sleValues = getSleFromInputs();
 
       if (!fullConfig.boards[currentBoardId]) {
         fullConfig.boards[currentBoardId] = {

--- a/options.js
+++ b/options.js
@@ -412,7 +412,7 @@ document.addEventListener('DOMContentLoaded', function () {
     boardSelect.innerHTML = '';
     const defaultOption = document.createElement('option');
     defaultOption.value = '';
-    defaultOption.textContent = 'Default (All Boards)';
+    defaultOption.textContent = 'Global Defaults';
     boardSelect.appendChild(defaultOption);
     Object.keys(fullConfig.boards).forEach((id) => {
       const opt = document.createElement('option');

--- a/popup.html
+++ b/popup.html
@@ -123,6 +123,9 @@
     }
     .footer-btn:hover { text-decoration: underline; }
     .copied-msg { color: #38a169; font-size: 12px; }
+    .import-status { font-size: 11px; margin-top: 7px; text-align: center; }
+    .import-status.success { color: #38a169; }
+    .import-status.error { color: #c53030; }
   </style>
 </head>
 <body>
@@ -171,7 +174,12 @@
   </div>
 
   <div class="section" id="exportSection" style="display:none">
-    <button class="btn btn-secondary btn-full" id="exportBtn">Export This Board's Config</button>
+    <div class="btn-row">
+      <button class="btn btn-secondary" id="exportBtn">Export Config</button>
+      <button class="btn btn-secondary" id="importBtn">Import Config</button>
+    </div>
+    <div id="importStatus" style="display:none"></div>
+    <input type="file" id="importFileInput" accept=".json" style="display:none">
   </div>
 
   <div class="footer">

--- a/popup.html
+++ b/popup.html
@@ -126,6 +126,14 @@
     .import-status { font-size: 11px; margin-top: 7px; text-align: center; }
     .import-status.success { color: #38a169; }
     .import-status.error { color: #c53030; }
+    .partial-notice {
+      color: #92400e;
+      background: #fffbeb;
+      border-color: #fcd34d;
+      font-size: 12px;
+      line-height: 1.4;
+      text-align: center;
+    }
   </style>
 </head>
 <body>
@@ -144,6 +152,8 @@
   </div>
 
   <div id="dashboardArea" style="display:none">
+    <div class="section partial-notice" id="partialNotice" style="display:none"></div>
+
     <div class="section">
       <div class="section-title">Total WIP</div>
       <div id="wipArea" class="state-msg">Loading…</div>

--- a/popup.html
+++ b/popup.html
@@ -169,8 +169,9 @@
     <div class="section-title">Configure Settings</div>
     <div class="btn-row">
         <button class="btn btn-secondary" id="thisBoardSettingsBtn" disabled>This Board</button>
-        <button class="btn btn-secondary" id="defaultSettingsBtn">Default (All Boards)</button>
+        <button class="btn btn-secondary" id="defaultSettingsBtn">Global Defaults</button>
     </div>
+    <div class="stat-hint" style="margin-top:6px">Boards inherit global defaults unless overridden per board.</div>
   </div>
 
   <div class="section" id="exportSection" style="display:none">

--- a/popup.js
+++ b/popup.js
@@ -134,7 +134,24 @@
       `</div>`;
   }
 
+  function renderPartialNotice(data) {
+    const el = document.getElementById('partialNotice');
+    const total = typeof data.boardCardTotal === 'number' ? data.boardCardTotal : 0;
+    const rendered = typeof data.renderedCardCount === 'number' ? data.renderedCardCount : 0;
+    // Only flag when we have a trustworthy board total and the board has not
+    // rendered all of its cards yet — every tally below is partial until then.
+    if (total > 0 && rendered < total) {
+      el.textContent =
+        `⏳ Showing ${rendered} of ${total} cards. ServiceNow loads cards as you ` +
+        `scroll — scroll through every lane to load them all for complete totals.`;
+      el.style.display = '';
+    } else {
+      el.style.display = 'none';
+    }
+  }
+
   function renderDashboard(data) {
+    renderPartialNotice(data);
     renderWipArea(data);
     renderAgeArea(data);
     renderFreshnessArea(data);

--- a/popup.js
+++ b/popup.js
@@ -19,13 +19,17 @@
   }
 
   function getBoardIdFromUrl(url) {
-    if (!url || !url.includes('vtb.do')) return null;
+    if (!url || (!url.includes('vtb.do') && !url.includes('agile_board.do'))) return null;
     // ServiceNow's navigation shell URL-encodes the inner URL, so sysparm_board=
     // may appear as sysparm_board%3D. Decode before parsing.
     let decoded = url;
     try { decoded = decodeURIComponent(url); } catch (_) {}
     const m = decoded.match(/sysparm_board=([^&]+)/);
     return m ? m[1] : null;
+  }
+
+  function isKnownBoardPage(url) {
+    return !!url && (url.includes('vtb.do') || url.includes('agile_board.do'));
   }
 
   function openOptions(boardId) {
@@ -182,6 +186,10 @@
           setAreasMessage('Board is still loading — click ↺ to retry.');
           return;
         }
+        if (!currentBoardId && response.boardId) {
+          currentBoardId = response.boardId;
+          document.getElementById('thisBoardSettingsBtn').disabled = false;
+        }
         renderDashboard(response);
       });
     });
@@ -220,9 +228,8 @@
       currentTab = tabs[0] || null;
       const url = currentTab ? currentTab.url : null;
       currentBoardId = getBoardIdFromUrl(url);
-      const isVtbPage = !!currentBoardId;
 
-      if (!isVtbPage) {
+      if (!isKnownBoardPage(url)) {
         document.getElementById('nonVtbNotice').style.display = '';
         document.getElementById('boardNameDisplay').textContent = 'Not on a VTB page';
         return;

--- a/popup.js
+++ b/popup.js
@@ -107,8 +107,7 @@
       `<div class="stat-row">` +
       `<span>${escHtml(data.staleEmoji)} Stale</span><strong>${data.staleCount}</strong>` +
       `</div>` +
-      `<div class="stat-hint">Stale after ${data.updateThresholdDays} days without update</div>` +
-    `<div class="stat-hint">Counts update as ServiceNow loads each lane — scroll through all lanes for a complete total.</div>`;
+      `<div class="stat-hint">Stale after ${data.updateThresholdDays} days without update</div>`;
   }
 
   function renderSleArea(data) {

--- a/popup.js
+++ b/popup.js
@@ -224,6 +224,42 @@
       }
     });
 
+    const importBtn = document.getElementById('importBtn');
+    const importFileInput = document.getElementById('importFileInput');
+    const importStatus = document.getElementById('importStatus');
+
+    function showImportStatus(msg, type) {
+      importStatus.textContent = msg;
+      importStatus.className = 'import-status ' + type;
+      importStatus.style.display = '';
+      if (type === 'success') {
+        setTimeout(function () { importStatus.style.display = 'none'; }, 4000);
+      }
+    }
+
+    importBtn.addEventListener('click', function () {
+      importFileInput.value = '';
+      importFileInput.click();
+    });
+
+    importFileInput.addEventListener('change', function () {
+      const file = importFileInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = function (e) {
+        const { error, config } = VTBShared.importBoardConfig(e.target.result, fullConfig, currentBoardId);
+        if (error) {
+          showImportStatus(error, 'error');
+        } else {
+          fullConfig = config;
+          VTBShared.saveConfig(fullConfig, function () {
+            showImportStatus('Config imported — reload the board to apply changes.', 'success');
+          });
+        }
+      };
+      reader.readAsText(file);
+    });
+
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       currentTab = tabs[0] || null;
       const url = currentTab ? currentTab.url : null;

--- a/shared.js
+++ b/shared.js
@@ -147,13 +147,13 @@ const VTBShared = (function () {
 
       if (!boardCfg.sle || typeof boardCfg.sle !== 'object') {
         boardCfg.sle = {
-          enabled: true, days: 0, approachingDays: 3,
+          enabled: false, days: 7, approachingDays: 3,
           showSummary: true, showBadgeEmojis: true, showBadgeBorder: true,
           approachingEmoji: '⚠️', breachedEmoji: '🔴',
         };
       } else {
-        if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = true;
-        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 0) boardCfg.sle.days = 0;
+        if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = false;
+        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 1) boardCfg.sle.days = 7;
         if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
         if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
         const legacyEscalation = typeof boardCfg.sle.showBadgeEscalation === 'boolean' ? boardCfg.sle.showBadgeEscalation : true;
@@ -371,8 +371,8 @@ const VTBShared = (function () {
     }
     if (incoming.sle && typeof incoming.sle === 'object') {
       target.sle = {
-        enabled: typeof incoming.sle.enabled === 'boolean' ? incoming.sle.enabled : true,
-        days: typeof incoming.sle.days === 'number' && incoming.sle.days >= 0 ? incoming.sle.days : 0,
+        enabled: typeof incoming.sle.enabled === 'boolean' ? incoming.sle.enabled : false,
+        days: typeof incoming.sle.days === 'number' && incoming.sle.days > 0 ? incoming.sle.days : 7,
         approachingDays: typeof incoming.sle.approachingDays === 'number' && incoming.sle.approachingDays >= 0 ? incoming.sle.approachingDays : 3,
         showSummary: typeof incoming.sle.showSummary === 'boolean' ? incoming.sle.showSummary : true,
         showBadgeEmojis: typeof incoming.sle.showBadgeEmojis === 'boolean' ? incoming.sle.showBadgeEmojis : (typeof incoming.sle.showBadgeEscalation === 'boolean' ? incoming.sle.showBadgeEscalation : true),

--- a/shared.js
+++ b/shared.js
@@ -153,7 +153,12 @@ const VTBShared = (function () {
         };
       } else {
         if (typeof boardCfg.sle.enabled !== 'boolean') boardCfg.sle.enabled = false;
-        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 1) boardCfg.sle.days = 7;
+        if (typeof boardCfg.sle.days !== 'number' || boardCfg.sle.days < 1) {
+          // days < 1 was the old "effectively off" sentinel (default was days: 0).
+          // Treat it as disabled rather than silently activating a 7-day target.
+          boardCfg.sle.days = 7;
+          boardCfg.sle.enabled = false;
+        }
         if (typeof boardCfg.sle.approachingDays !== 'number' || boardCfg.sle.approachingDays < 0) boardCfg.sle.approachingDays = 3;
         if (typeof boardCfg.sle.showSummary !== 'boolean') boardCfg.sle.showSummary = true;
         const legacyEscalation = typeof boardCfg.sle.showBadgeEscalation === 'boolean' ? boardCfg.sle.showBadgeEscalation : true;

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -82,6 +82,7 @@ Runs `test/explore.js` — a non-Playwright Node script that navigates to a boar
 | `cases/05-summary-bar.js` | SLE summary bar appears when SLE is enabled; is absent when disabled |
 | `cases/06-sle-breach.js` | Breached cards show the breach emoji and red outline; no indicators when SLE is disabled |
 | `cases/07-freshness-count-complete.js` | Popup freshness total counts every in-DOM card at load (no scrolling needed), even when most lanes are virtual-scroll hidden |
+| `cases/08-wip-freshness-hidden.js` | WIP-lane freshness restriction counts off-screen (display:none) cards in the configured lanes; restricting to all lanes equals no restriction |
 
 ## Source Files vs. Generated Artifacts
 

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -131,4 +131,4 @@ To point the harness at a different board — for example a larger board with mo
 
 **Tests time out on board load** — The board may have been deleted or `testingBoardUrl` is wrong. Update `testingBoardUrl` in `test-local/config.json` to a working VTB board URL.
 
-**All cards show "not enhanced"** — The extension content script may not be running. Check `edge://extensions/` to confirm the extension is enabled and that the board URL matches `*://*.service-now.com/*vtb.do*`.
+**All cards show "not enhanced"** — The extension content script may not be running. Check `edge://extensions/` to confirm the extension is enabled and that the board URL matches `*://*.service-now.com/*vtb.do*` or `*://*.service-now.com/*agile_board.do*`.

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -61,7 +61,7 @@ Subsequent runs will navigate directly to the board without prompting.
 npm run test:assert
 ```
 
-Runs all six test cases in `test/cases/` serially (one worker, one shared profile). Each case opens its own Edge window, navigates to the configured board, and makes assertions. The HTML report is written to `test-local/playwright-report/`.
+Runs every test case in `test/cases/` serially (one worker, one shared profile). Each case opens its own Edge window, navigates to the configured board, and makes assertions. The HTML report is written to `test-local/playwright-report/`.
 
 ### Exploration / diagnostics
 
@@ -70,6 +70,15 @@ npm run test:explore
 ```
 
 Runs `test/explore.js` — a non-Playwright Node script that navigates to a board, captures screenshots, and dumps DOM diagnostic data to `test-local/output/`. Use this to inspect a specific board's structure or debug a suspected issue before writing an assertion.
+
+### Investigating board-specific rendering (read before deep DOM debugging)
+
+ServiceNow VTB has several non-obvious rendering behaviours that have caused real bugs — they are documented in the **ServiceNow VTB DOM Architecture** section of the repo-root `CLAUDE.md`. Read that first. The two that most affect *testing*:
+
+- **The harness renders everything, so it cannot reproduce lazy-loading states.** In automated Edge, a board renders all its cards into the DOM regardless of window size or even with CDP network throttling — so a problem a user sees in their real browser (e.g. "the popup only counts 22 of 136 cards until I scroll") will *not* reproduce as a low count here. Do not conclude the bug doesn't exist. Instead read the DOM directly: count `display:none` cards, sum `.vtb-lane-header-count`, and compare against rendered counts to reason about what the user's slower/narrower environment would show.
+- **Geometry lies for off-screen cards; the Angular model is out of reach for the extension.** `getBoundingClientRect` is zero-size for `display:none` cards, and `window.angular` is only visible from `frame.evaluate()` (page main world), never from the content script (isolated world). When debugging card→lane or freshness issues, resolve lanes structurally (`v-lane-index`, `aria-label="Cards in lane: …"`), not by geometry, and verify against `.vtb-lane-header-count` totals.
+
+**Throwaway probe pattern.** For one-off investigation, write a small Node script in `test-local/` (gitignored) that `import`s `../test/helpers.js`, calls `helpers.launchEdge()` + `helpers.waitForVtbPage()` + `helpers.getVtbFrame()`, then uses `frame.evaluate()` to dump whatever DOM/Angular structure you need (ancestor chains, attributes, per-lane counts). Run it with `node test-local/your-probe.mjs`, learn what you need, then delete it. Several findings in `CLAUDE.md` came from exactly this loop. To inspect the numbers the toolbar popup would show, use `helpers.queryPopup(context, extensionId)`, which sends the real `VTB_POPUP_QUERY` message and returns the content script's response.
 
 ## Test Cases
 
@@ -91,7 +100,7 @@ Runs `test/explore.js` — a non-Playwright Node script that navigates to a boar
 ```
 test/
   TESTING.md            ← this file
-  helpers.js            ← shared utilities (launchEdge, navigateToBoard, setConfig, …)
+  helpers.js            ← shared utilities (launchEdge, navigateToBoard, waitForBoardEnhanced, setConfig, queryPopup, …)
   playwright.config.js  ← testDir, testMatch, timeout, workers, reporter settings
   explore.js            ← diagnostic script for board investigation
   cases/                ← numbered assertion test files
@@ -119,11 +128,13 @@ To point the harness at a different board — for example a larger board with mo
 
 ## Adding a New Test Case
 
-1. Create `test/cases/07-your-feature.js` (next number in sequence).
+1. Create `test/cases/NN-your-feature.js` (next number in sequence).
 2. Import helpers: `import { test, expect } from '@playwright/test'; import * as helpers from '../helpers.js';`
 3. Use `helpers.launchEdge()`, `helpers.waitForVtbPage(context)`, and `helpers.waitForBoardEnhanced(vtbPage)` to get a live board frame.
 4. Use `helpers.setConfig(context, extensionId, cfg)` + `vtbPage.reload()` to inject specific config before asserting.
-5. Always call `context.close()` in `afterAll`.
+5. To assert on the toolbar popup's reported totals, use `helpers.queryPopup(context, extensionId)` (sends the real `VTB_POPUP_QUERY`).
+6. For features whose correctness depends on off-screen cards (freshness counts, lane restriction, totals), assert with cards present but `display:none` — that is where geometry-based logic historically failed. See `cases/07` and `cases/08`.
+7. Always call `context.close()` in `afterAll`.
 
 ## Troubleshooting
 
@@ -134,3 +145,5 @@ To point the harness at a different board — for example a larger board with mo
 **Tests time out on board load** — The board may have been deleted or `testingBoardUrl` is wrong. Update `testingBoardUrl` in `test-local/config.json` to a working VTB board URL.
 
 **All cards show "not enhanced"** — The extension content script may not be running. Check `edge://extensions/` to confirm the extension is enabled and that the board URL matches `*://*.service-now.com/*vtb.do*` or `*://*.service-now.com/*agile_board.do*`.
+
+**A user reports low/incomplete counts you can't reproduce** — The harness renders all cards while the user's browser may not (see "Investigating board-specific rendering" above and the DOM Architecture section in the repo-root `CLAUDE.md`). Reason from the DOM (`display:none` counts, `.vtb-lane-header-count` totals) rather than expecting the partial state to reproduce. If the feature uses lane lookup, confirm cards resolve to a lane while hidden — geometry (`getBoundingClientRect`) silently fails for `display:none` cards.

--- a/test/TESTING.md
+++ b/test/TESTING.md
@@ -81,6 +81,7 @@ Runs `test/explore.js` — a non-Playwright Node script that navigates to a boar
 | `cases/04-freshness.js` | Freshness indicators (✅/❌) appear next to each card's last-updated timestamp |
 | `cases/05-summary-bar.js` | SLE summary bar appears when SLE is enabled; is absent when disabled |
 | `cases/06-sle-breach.js` | Breached cards show the breach emoji and red outline; no indicators when SLE is disabled |
+| `cases/07-freshness-count-complete.js` | Popup freshness total counts every in-DOM card at load (no scrolling needed), even when most lanes are virtual-scroll hidden |
 
 ## Source Files vs. Generated Artifacts
 

--- a/test/cases/06-sle-breach.js
+++ b/test/cases/06-sle-breach.js
@@ -68,7 +68,7 @@ test('breach emoji appears on badges when cards exceed SLE target', async () => 
 test('no breach indicators when SLE is disabled', async () => {
   const cfg = helpers.defaultConfig();
   cfg.boards[boardId] = {
-    sle: { enabled: false, days: 0 },
+    sle: { enabled: false, days: 7 },
   };
 
   await helpers.setConfig(context, extensionId, cfg);

--- a/test/cases/07-freshness-count-complete.js
+++ b/test/cases/07-freshness-count-complete.js
@@ -59,4 +59,11 @@ test('popup freshness total counts every in-DOM card without scrolling', async (
   // The popup total must already equal every indicator drawn in the DOM —
   // proving the count does not depend on the user scrolling hidden lanes.
   expect(popup.freshCount + popup.staleCount).toBe(dom.indicatorCount);
+
+  // The authoritative board total comes from the lane header counts and must
+  // cover every rendered card. On a fully-rendered board the two are equal,
+  // so the popup shows no "still loading" partial notice.
+  expect(popup.boardCardTotal).toBeGreaterThan(0);
+  expect(popup.renderedCardCount).toBeLessThanOrEqual(popup.boardCardTotal);
+  expect(popup.renderedCardCount).toBe(dom.totalCards);
 });

--- a/test/cases/07-freshness-count-complete.js
+++ b/test/cases/07-freshness-count-complete.js
@@ -1,0 +1,62 @@
+// Verifies the popup's freshness total is COMPLETE at load — i.e. it counts
+// every card in the DOM without requiring the user to scroll through lanes.
+//
+// ServiceNow's vtb-viewport-on-scroll directive keeps off-screen cards in the
+// DOM as display:none (not removed), and the content script draws an indicator
+// on every card at load. So the accumulated fresh/stale total the popup reads
+// should already equal the full in-DOM indicator count before any scrolling.
+//
+// This test guards against a regression where counting reverts to a
+// visible-only / scroll-dependent approach (the reason the old popup carried a
+// "scroll through all lanes for a complete total" qualifier, now removed).
+
+import { test, expect } from '@playwright/test';
+import * as helpers from '../helpers.js';
+
+let context, extensionId, vtbPage, frame;
+
+test.beforeAll(async () => {
+  context     = await helpers.launchEdge();
+  extensionId = await helpers.getExtensionId(context);
+  vtbPage     = await helpers.waitForVtbPage(context);
+  frame       = await helpers.waitForBoardEnhanced(vtbPage);
+});
+
+test.afterAll(async () => { await context.close(); });
+
+test('popup freshness total counts every in-DOM card without scrolling', async () => {
+  const cfg = helpers.defaultConfig();
+  cfg.defaultConfig.enableUpdateIndicator = true;
+  await helpers.setConfig(context, extensionId, cfg);
+  await vtbPage.reload({ waitUntil: 'networkidle' });
+  frame = await helpers.waitForBoardEnhanced(vtbPage);
+
+  const timeAgoCount = await frame.evaluate(() =>
+    document.querySelectorAll('sn-time-ago').length
+  );
+  if (timeAgoCount === 0) {
+    console.log('  SKIP: no sn-time-ago elements found on this board');
+    return;
+  }
+
+  // Ground truth: indicators present in the DOM right now (no scrolling).
+  const dom = await frame.evaluate(() => {
+    const cards = [...document.querySelectorAll('.vtb-card-component-wrapper')];
+    const indicators = [...document.querySelectorAll('.vtb-enhancer-update-indicator')];
+    return {
+      totalCards: cards.length,
+      hidden: cards.filter(c => c.style.display === 'none').length,
+      indicatorCount: indicators.length,
+    };
+  });
+
+  // The scenario only has teeth when some cards are virtual-scroll hidden.
+  expect(dom.indicatorCount).toBeGreaterThan(0);
+
+  const popup = await helpers.queryPopup(context, extensionId);
+  expect(popup).not.toBeNull();
+
+  // The popup total must already equal every indicator drawn in the DOM —
+  // proving the count does not depend on the user scrolling hidden lanes.
+  expect(popup.freshCount + popup.staleCount).toBe(dom.indicatorCount);
+});

--- a/test/cases/08-wip-freshness-hidden.js
+++ b/test/cases/08-wip-freshness-hidden.js
@@ -1,0 +1,88 @@
+// Verifies WIP-lane freshness restriction counts cards in the configured lanes
+// even when they are scrolled off-screen (display:none).
+//
+// Regression guard: lane resolution once relied on getBoundingClientRect, which
+// returns a zero-size rect for hidden cards, so every off-screen card failed the
+// WIP-lane check and was dropped from the freshness tally. On large boards that
+// undercounted freshness badly (e.g. 22 instead of 81). The fix resolves a
+// card's lane structurally (v-lane-index / aria-label), independent of layout.
+//
+// Strategy: restricting freshness to EVERY lane must yield the same total as no
+// restriction at all — restricting to all lanes excludes nothing. Before the
+// fix the all-lanes run collapsed to roughly the visible-card count.
+
+import { test, expect } from '@playwright/test';
+import * as helpers from '../helpers.js';
+
+let context, extensionId, vtbPage, frame, boardId;
+
+test.beforeAll(async () => {
+  context     = await helpers.launchEdge();
+  extensionId = await helpers.getExtensionId(context);
+  vtbPage     = await helpers.waitForVtbPage(context);
+  frame       = await helpers.waitForBoardEnhanced(vtbPage);
+  boardId = await frame.evaluate(() => {
+    const m = window.location.search.match(/[?&]sysparm_board=([^&]+)/);
+    return m ? m[1] : null;
+  });
+  expect(boardId).toBeTruthy();
+});
+
+test.afterAll(async () => { await context.close(); });
+
+test('WIP-restricted freshness counts off-screen cards in the configured lanes', async () => {
+  // Discover every lane name on the board.
+  const laneNames = await frame.evaluate(() => {
+    const out = [];
+    document.querySelectorAll('.vtb-lane-header-title').forEach((el) => {
+      const label = el.querySelector('label, input');
+      const name = ((label ? (label.value || label.textContent) : el.textContent) || '').trim();
+      if (name && !out.includes(name)) out.push(name);
+    });
+    return out;
+  });
+  if (laneNames.length === 0) {
+    console.log('  SKIP: no lane headers found on this board');
+    return;
+  }
+
+  const counts = await frame.evaluate(() => {
+    const cards = [...document.querySelectorAll('.vtb-card-component-wrapper')];
+    return {
+      hidden: cards.filter(c => c.style.display === 'none').length,
+      visible: cards.filter(c => c.style.display !== 'none').length,
+    };
+  });
+  if (counts.hidden === 0) {
+    console.log('  SKIP: no off-screen cards on this board — restriction path has no teeth here');
+    return;
+  }
+
+  // Run 1: freshness with no WIP restriction.
+  const noRestrict = helpers.defaultConfig();
+  noRestrict.boards[boardId] = { enableUpdateIndicator: true, enableWipLanes: false, wipLanes: [] };
+  await helpers.setConfig(context, extensionId, noRestrict);
+  await vtbPage.reload({ waitUntil: 'networkidle' });
+  await helpers.waitForBoardEnhanced(vtbPage);
+  const unrestricted = await helpers.queryPopup(context, extensionId);
+  const unrestrictedTotal = unrestricted.freshCount + unrestricted.staleCount;
+
+  // Run 2: freshness restricted to EVERY lane — must match the unrestricted run.
+  const allLanes = helpers.defaultConfig();
+  allLanes.boards[boardId] = { enableUpdateIndicator: true, enableWipLanes: true, wipLanes: laneNames };
+  await helpers.setConfig(context, extensionId, allLanes);
+  await vtbPage.reload({ waitUntil: 'networkidle' });
+  await helpers.waitForBoardEnhanced(vtbPage);
+  const restricted = await helpers.queryPopup(context, extensionId);
+  const restrictedTotal = restricted.freshCount + restricted.staleCount;
+
+  // Restricting to all lanes excludes nothing, so the totals must be identical.
+  // This is the core regression assertion: the old geometry-based lane lookup
+  // dropped off-screen cards, collapsing the restricted total to roughly the
+  // visible-card count.
+  expect(restrictedTotal).toBe(unrestrictedTotal);
+
+  // And the restricted total must include off-screen cards, so it exceeds the
+  // count of cards that were visible at load.
+  expect(restrictedTotal).toBeGreaterThan(counts.visible);
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -112,14 +112,14 @@ export async function setConfig(context, extensionId, cfg) {
 // is required, waits up to 5 minutes for the user to log in before continuing.
 export async function navigateToBoard(context, url) {
   const page = await context.newPage();
-  const isVtb = u => /service-now\.com.*vtb\.do/.test(u);
+  const isOnServiceNow = u => { try { return new URL(u).hostname.endsWith('.service-now.com'); } catch { return false; } };
 
   await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 }).catch(() => null);
 
-  if (!isVtb(page.url())) {
+  if (!isOnServiceNow(page.url())) {
     console.log('  Session expired — please log in. Waiting up to 5 minutes...');
     await page.waitForFunction(
-      () => /service-now\.com.*vtb\.do/.test(window.location.href),
+      () => window.location.hostname.endsWith('.service-now.com'),
       { timeout: 5 * 60 * 1000 }
     );
   }
@@ -152,11 +152,11 @@ export async function waitForVtbPage(context) {
   return navigateToBoard(context, BOARD_URL);
 }
 
-// The content script runs in the inner $vtb.do iframe, not the outer Now nav shell.
-// The outer shell URL encodes vtb.do as %24vtb.do in a query param — we skip that
-// and look only at child frames whose URL directly serves $vtb.do as a path.
+// The content script runs in the inner $vtb.do or $agile_board.do iframe, not the
+// outer Now nav shell. The outer shell URL encodes the board path as a query param —
+// we skip that and look only at child frames whose URL directly serves the board as a path.
 export async function getVtbFrame(page, timeout = 30_000) {
-  const isInnerVtb = url => /\/\$?vtb\.do(\?|&|$)/.test(url);
+  const isInnerVtb = url => /\/\$?(vtb|agile_board)\.do(\?|&|$)/.test(url);
   const deadline = Date.now() + timeout;
 
   while (Date.now() < deadline) {
@@ -187,7 +187,7 @@ export async function waitForBoardEnhanced(page, timeout = 60_000) {
 // For explore mode: waits for the board to load, then gives the extension time to run.
 // Does NOT require any cards to be enhanced — captures state as-is.
 export async function waitForBoardLoaded(page, timeout = 60_000) {
-  const frame = await getVtbFrame(page);
+  const frame = await getVtbFrame(page, timeout);
   console.log(`  [waitForBoardLoaded] frame URL: ${frame.url()}`);
 
   const found = await frame.waitForFunction(
@@ -196,7 +196,17 @@ export async function waitForBoardLoaded(page, timeout = 60_000) {
   ).then(() => true).catch(() => false);
 
   if (!found) {
-    console.log('  [waitForBoardLoaded] No .vtb-card-component-wrapper found — board may use different selectors or have no cards');
+    console.log('  [waitForBoardLoaded] No .vtb-card-component-wrapper found — probing DOM for card/lane class names...');
+    const domProbe = await frame.evaluate(() => {
+      const allClasses = new Set();
+      document.querySelectorAll('*').forEach(el => el.classList.forEach(c => allClasses.add(c)));
+      const cardLike = [...allClasses].filter(c => /card|task|story|issue|item|ticket|work.?item/i.test(c)).sort();
+      const laneLike = [...allClasses].filter(c => /lane|column|swim|sprint|board/i.test(c)).sort();
+      return { cardLike, laneLike, totalClasses: allClasses.size };
+    });
+    console.log(`  DOM class probe (${domProbe.totalClasses} total classes):`);
+    console.log(`    Card-like: ${domProbe.cardLike.join(', ') || '(none)'}`);
+    console.log(`    Lane-like: ${domProbe.laneLike.join(', ') || '(none)'}`);
   } else {
     const count = await frame.evaluate(
       () => document.querySelectorAll('.vtb-card-component-wrapper').length

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -108,6 +108,31 @@ export async function setConfig(context, extensionId, cfg) {
   await page.close();
 }
 
+// Sends the same VTB_POPUP_QUERY the toolbar popup uses and returns the
+// content script's response (board health totals). Runs from an extension
+// page so chrome.tabs is available. The extension has no "tabs" permission,
+// so tab URLs are unreadable — instead we message every tab and take the one
+// frame that answers (only the inner board frame, which has a boardId, does).
+export async function queryPopup(context, extensionId) {
+  const page = await context.newPage();
+  await page.goto(`chrome-extension://${extensionId}/options.html`);
+  const response = await page.evaluate(async () => {
+    const tabs = await chrome.tabs.query({});
+    for (const t of tabs) {
+      const resp = await new Promise(resolve => {
+        chrome.tabs.sendMessage(t.id, { type: 'VTB_POPUP_QUERY' }, r => {
+          if (chrome.runtime.lastError) resolve(null);
+          else resolve(r);
+        });
+      });
+      if (resp && typeof resp.freshCount === 'number') return resp;
+    }
+    return null;
+  });
+  await page.close();
+  return response;
+}
+
 // Navigate directly to a known board URL. If the session has expired and auth
 // is required, waits up to 5 minutes for the user to log in before continuing.
 export async function navigateToBoard(context, url) {


### PR DESCRIPTION
## Summary

- **agile_board.do support** — extension now activates on both `vtb.do` and `agile_board.do` URLs; popup correctly detects and queries the inner board frame on both page types
- **Freshness count completeness** — the summary bar and popup freshness totals now count every card in the DOM at load, including virtual-scroll hidden cards; removed the "scroll through all lanes" qualifier that was no longer needed
- **WIP-lane freshness bug fix** — off-screen (`display:none`) cards were silently dropped from WIP-restricted freshness counts because `getBoundingClientRect` returns a zero-size rect for hidden elements; lane lookup now resolves structurally via `v-lane-index` and `aria-label`, so hidden cards are counted correctly
- **Partial-load notice** — when ServiceNow hasn't finished rendering all cards, the popup now flags it with the authoritative total from the lane header counts vs. the rendered count
- **SLE defaults changed** — SLE is now off by default with a 7-day target; enabling SLE requires a positive non-zero day value
- **Import Config on popup** — the popup now has an Import Config button matching the options page behavior
- **Global Defaults rename** — "Default (All Boards)" renamed to "Global Defaults" with a hint that boards inherit these settings unless overridden per board
- **Summary bar redesign** — replaced the colored warning box with uniform pill chips that match the extension's UI language; breached/approaching pills only use colored fills when their count is non-zero; bar is vertically centered across the board name + subtitle lines
- **Architecture docs** — `CLAUDE.md` and `test/TESTING.md` updated with the ServiceNow VTB DOM architecture gotchas discovered during this work (nested iframe, virtual scroll, lazy timestamps, separate header/body subtrees, `v-lane-index`, authoritative lane header counts, Angular isolation boundary)

## Test plan

- [x] Load the extension on a `vtb.do` board — all features work as before
- [x] Load on an `agile_board.do` board — popup shows board data; summary bar appears
- [x] Open popup: freshness totals match the indicator count in the DOM without scrolling
- [x] On a board with many off-screen cards and WIP lanes configured, popup freshness total matches the unrestricted total (regression for the `getBoundingClientRect` bug)
- [x] SLE disabled by default; enabling with 0 days shows a validation error
- [x] Import Config from popup imports correctly and shows confirmation
- [x] Summary bar pill chips: neutral gray when counts are zero, colored when non-zero
- [ ] `npm run test:assert` — all 8 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)